### PR TITLE
Update Discord role permissions post

### DIFF
--- a/content/collections/posts/2023-08-14.seamless-role-management-with-discord.md
+++ b/content/collections/posts/2023-08-14.seamless-role-management-with-discord.md
@@ -1,106 +1,157 @@
 ---
 id: bfcf1365-584b-4648-9293-6ba4a8a53538
 blueprint: post
-title: 'Seamless Role Management: Discord and Laravel Unite'
+title: 'Using Discord roles for Laravel permissions'
 categories:
     - laravel
     - tips+tricks
 image: posts/2023-08-14.seamless-role-management-with-discord.jpg
 author: gummibeer
-description: 'Discover how we streamlined role management for our GTA:RP community by syncing Discord roles with Laravel Nova Backoffice, creating a unified and efficient system.'
+description: 'How I made Discord the source of truth for our Laravel Nova permissions instead of maintaining the same team roles twice.'
 ---
 
-Being part of our GTA:RP server management team, I've come to realize the importance of effective organization and communication.
-With a diverse team of about 30 individuals and a multi-level hierarchy, maintaining roles and permissions consistently across platforms was quite a puzzle.
-Here's how, in my role as the Development Team Lead, I stumbled upon a simple yet effective solution that uses Discord roles to seamlessly manage our Laravel Nova Backoffice.
+When I built this, we were a team of around 30 people managing a FiveM GTA:RP server.
+We had several departments and a roughly three-level hierarchy with head admins, team leads and team members.
 
-## Solving the Role Puzzle
+Like a lot of gaming communities, Discord was our central place for communication and team management.
+So all those departments and hierarchy levels already existed as Discord roles.
 
-Our GTA:RP server community is like a well-oiled machine, with different roles like Head Admins, Team Leads, and Team Members working together.
-However, keeping track of roles and permissions between Discord and our Laravel Nova Backoffice wasn't as smooth as we wanted it to be.
-The discrepancies caused confusion, leading us to think about a better way.
+And then we had another set of roles for our Laravel Nova backoffice.
 
-## An Unexpected Solution - Discord Role Integration
+You can probably guess what happened.
 
-In my quest to find a solution, I realized that the key might be in the very thing we were already using - Discord roles.
-Why not use them as the foundation for our Backoffice roles? This simple idea ignited the spark for an integration that promised to eliminate inconsistencies and streamline our workflow.
+Someone changed departments, got promoted or left a team, the Discord roles were updated and the backoffice was forgotten.
+Or the other way around.
+Two places describing the same thing will eventually get out of sync.
 
-Practical Benefits:
+So I stopped trying to keep both role systems synchronized and made Discord the source of truth for the permissions in Laravel instead.
 
-1. **Uniformity Across Platforms**: By integrating Discord roles into our Backoffice, we achieved a unified roles system that eliminated any mismatch.
-2. **Time Saved, Errors Reduced**: The days of manually managing roles were gone, replaced by an automated process that saved time and minimized errors.
-3. **Simpler Onboarding**: Adding new members became hassle-free – correctly assigning Discord roles automatically set up their Backoffice roles.
-4. **Boosted Security**: Aligning Backoffice roles with Discord roles tightened our community's security, ensuring the right access for the right people.
-5. **Adapting to Change**: As our community evolved, our integration adapted smoothly, accommodating changes without a hitch.
+## Discord is the source of truth
 
-## Implementing Discord Role Integration
+I don't need every role from our Discord server inside Laravel.
+There are plenty of roles that are only relevant for Discord itself.
 
-Let's take a look at how we implemented the integration using code snippets.
-Below is how we defined the relevant Discord roles using enums:
+The roles the application actually cares about are defined in a backed enum:
 
 ```php
+<?php
+
+namespace App\Enums;
+
 enum DiscordRole: string
 {
-    case LEAD_ADMINISTRATOR = 'xxxxxxxxxxxxxxxxx';  // Anonymized role ID
-    // ... other roles
-    case SUPPORTER = 'xxxxxxxxxxxxxxxxx';  // Anonymized role ID
+    case LEAD_ADMINISTRATOR = '100000000000000001';
+
+    case ADMINISTRATOR = '100000000000000002';
+
+    case LEAD_CONCEPTIONER = '100000000000000003';
+
+    case LEAD_DEVELOPER = '100000000000000004';
+    case DEVELOPER = '100000000000000005';
+    case SCRIPTER = '100000000000000006';
+    case MODDER_CLOTHES = '100000000000000007';
+    case MODDER_VEHICLES = '100000000000000008';
+    case MAPPER = '100000000000000009';
+    case FACILITYMANAGER = '100000000000000010';
+
+    case LEAD_SUPPORTER = '100000000000000011';
+    case SUPPORT = '100000000000000012';
+    case FRACTIONMANAGER = '100000000000000013';
+    case COMMUNITYMANAGER = '100000000000000014';
+
+    case LEAD_WHITELIST = '100000000000000015';
+    case WHITELIST = '100000000000000016';
+
+    case LAWMAKER = '100000000000000017';
+    case WEAZELNEWS = '100000000000000018';
 }
 ```
 
-Here's the method on the User model to retrieve the Discord roles and check if the user has any of the given roles:
+The values are the Discord role ID Snowflakes. I anonymized them here for obvious reasons.
+
+Using the IDs instead of role names also means Laravel doesn't care if someone renames a role in Discord.
+The enum gives me readable names in the application while Discord keeps being responsible for the actual role assignment.
+
+## Getting the Discord roles
+
+The `User` model exposes the relevant Discord roles as an attribute and has a small helper to check them:
 
 ```php
-use Illuminate\Database\Eloquent\Model;
-
-class User extends Model
+/**
+ * @return Collection<array-key, DiscordRole>
+ */
+public function getDiscordRolesAttribute(): Collection
 {
-    // ... other methods
-
-    /**
-     * @return Collection<array-key, DiscordRole>
-     */
-    public function getDiscordRolesAttribute(): Collection
-    {
-        if ($this->discord_id === null) {
-            return collect();
-        }
-
-        return rescue(
-            callback: fn () => Cache::swr(
-                key: $this->getCacheKey('discord_roles'),
-                tts: CarbonInterval::minute()->totalSeconds,
-                ttl: CarbonInterval::day()->totalSeconds,
-                callback: function (): Collection {
-                    $member = app(DiscordConnector::class)->guild()->getGuildMember(
-                        guildId: new Snowflake(config('services.discord.guild_id')),
-                        userId: new Snowflake($this->discord_id),
-                    );
-
-                    return collect($member->roles)
-                        ->map(fn (string $id) => DiscordRole::tryFrom($id))
-                        ->filter()
-                        ->values();
-                }
-            ),
-            rescue: collect(),
-        );
+    if ($this->discord_id === null) {
+        return collect();
     }
 
-    public function hasDiscordRole(DiscordRole ...$roles): bool
-    {
-        return $this->discord_roles->contains(fn (DiscordRole $role): bool => in_array($role, $roles, true));
+    if (in_array($this->role, [UserRole::GUEST(), UserRole::PLAYER()], true)) {
+        return collect();
     }
+
+    return rescue(
+        callback: fn () => Cache::swr(
+            key: $this->getCacheKey('discord_roles'),
+            tts: CarbonInterval::minute()->totalSeconds,
+            ttl: CarbonInterval::day()->totalSeconds,
+            callback: function (): Collection {
+                $member = app(DiscordConnector::class)->guild()->getGuildMember(
+                    guildId: new Snowflake(config('services.discord.guild_id')),
+                    userId: new Snowflake($this->discord_id),
+                );
+
+                return collect($member->roles)
+                    ->map(fn (string $id) => DiscordRole::tryFrom($id))
+                    ->filter()
+                    ->values();
+            }
+        ),
+        rescue: collect(),
+    );
+}
+
+public function hasDiscordRole(DiscordRole ...$roles): bool
+{
+    return $this->discord_roles->contains(fn (DiscordRole $role): bool => in_array($role, $roles, true));
 }
 ```
 
-In case you wonder about the logic within the `User->getDiscordRolesAttribute()` method, it uses a Discord SDK I'm working on right now.
-It's powered by [Saloon](https://github.com/saloonphp/saloon) and provides access to the Discord API with simple HTTP API calls instead of the websocket approach.
+There are a few details in there that matter.
 
-Here's an example policy that uses the Discord role check to control access within our Laravel Nova Backoffice:
+Users without a connected Discord account obviously don't have Discord roles.
+Guests and normal players don't need backoffice permissions either, so I don't even make an API request for them.
+
+For actual team members I fetch the guild member from Discord and map its role IDs through the `DiscordRole` enum.
+`tryFrom()` plus `filter()` means all the Discord-only roles simply disappear here.
+Laravel only sees roles I explicitly added to the enum.
+
+The result is cached because calling Discord for every policy check would be pretty stupid.
+And `rescue()` returns an empty collection if the Discord request fails, so a failing API doesn't accidentally grant permissions.
+It can lock somebody out until the data is available again, but for authorization I prefer that direction of failure.
+
+The `hasDiscordRole()` helper is intentionally an **any-of** check.
+Pass one role or ten roles and it returns `true` as soon as the user has one of them.
+
+## Policies stay boring
+
+With that in place there isn't anything Discord-specific left to do in Nova.
+The policies just check the roles they need:
 
 ```php
+<?php
+
+namespace App\Policies;
+
+use App\Enums\DiscordRole;
+use App\Models\Post;
+use App\Models\User as AuthUser;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
 class PostPolicy
 {
+    use HandlesAuthorization;
+
     public function viewAny(AuthUser $auth): bool
     {
         return $auth->hasDiscordRole(
@@ -109,19 +160,71 @@ class PostPolicy
         );
     }
 
-    // ... other methods
+    public function view(AuthUser $auth, Post $post): bool
+    {
+        return $auth->hasDiscordRole(
+            DiscordRole::LEAD_SUPPORTER,
+            DiscordRole::ADMINISTRATOR,
+        );
+    }
+
+    public function create(AuthUser $auth): bool
+    {
+        return $auth->hasDiscordRole(
+            DiscordRole::LEAD_SUPPORTER,
+            DiscordRole::ADMINISTRATOR,
+        );
+    }
+
+    public function update(AuthUser $auth, Post $post): bool
+    {
+        return $auth->hasDiscordRole(
+            DiscordRole::LEAD_SUPPORTER,
+            DiscordRole::ADMINISTRATOR,
+        );
+    }
+
+    public function delete(AuthUser $auth, Post $post): bool
+    {
+        return $auth->hasDiscordRole(
+            DiscordRole::ADMINISTRATOR,
+        );
+    }
 }
 ```
 
-By integrating these checks, our Backoffice access was seamlessly controlled based on the users' Discord roles.
+In this example lead supporters and administrators can work with posts, but deleting one is restricted to administrators.
+Nothing unusual from Laravel's perspective.
 
-## Continuing the Journey
+And that's also why this isn't really a Nova-specific solution.
+Nova happened to be the backoffice we used, but the authorization is implemented with normal Laravel policies and gates.
+If your backoffice uses those too - Filament or something custom for example - the same approach works there as well.
 
-The beauty of this integration lies in its simplicity and practicality.
-It's not a masterpiece, but it's a testament to how ingenuity and teamwork can lead to effective solutions in our unique community.
+## It's not really a sync
 
-## Conclusion
+I called this a Discord role sync originally, but that's slightly misleading.
+There is no second copy of the Discord team roles in the database that has to be synchronized.
 
-Our GTA:RP server community's journey is a reminder that innovation doesn't have to be complex to be effective.
-Integrating Discord roles with Laravel Nova Backoffice is a solution that has helped us work better together, without any unnecessary showmanship.
-As we move forward, I'm excited to see how this integration will continue to evolve alongside our community, proving that sometimes the simplest solutions are the most valuable.
+Laravel asks Discord which roles the user currently has, keeps that result in cache and uses it for authorization.
+That's the whole point.
+
+Discord was already where we managed team membership.
+When someone joined another department or became a team lead, that role had to be changed there anyway.
+
+The backoffice was the second place that needed the same change - and it was forgotten.
+
+And that's not really specific to our team.
+If you maintain the same roles and permissions manually in two different systems, one of them will eventually be forgotten or drift out of sync.
+That's the whole reason companies centralize this stuff with Active Directory, Entra ID, LDAP or similar systems.
+
+So instead of trying to become better at maintaining duplicate data, I removed the duplicate source of truth.
+
+There is one tradeoff worth keeping in mind: the roles are cached.
+That's great for not hammering the Discord API, but it also means a permission change isn't necessarily visible in Laravel immediately.
+With permissions where revocation has to take effect right now, I would use a shorter stale window or explicitly invalidate that user's cache when the role changes.
+
+For our backoffice that tradeoff was fine.
+And compared to maintaining the same organizational structure twice, it was a lot less annoying.
+
+That's it.
+Discord already knew who belonged to which team, so Laravel stopped pretending it needed its own version of that information.

--- a/content/collections/posts/2023-08-14.seamless-role-management-with-discord.md
+++ b/content/collections/posts/2023-08-14.seamless-role-management-with-discord.md
@@ -117,6 +117,9 @@ public function hasDiscordRole(DiscordRole ...$roles): bool
 }
 ```
 
+The `DiscordConnector` in that snippet comes from [my Discord SDK](https://github.com/Astrotomic/discord-sdk).
+It wraps Discord's HTTP API and is built on top of Saloon, so for this use case I can simply fetch the guild member without having to run a websocket client.
+
 There are a few details in there that matter.
 
 Users without a connected Discord account obviously don't have Discord roles.
@@ -200,22 +203,22 @@ Our backoffice happened to use Nova, so that's where I used this first.
 But nothing about the approach depends on Nova. The authorization is implemented with normal Laravel policies and gates.
 If you're using Filament, another admin panel or something custom on top of Laravel's authorization layer, the same idea applies there as well.
 
-## It's not really a sync
+## One source of truth
 
-I called this a Discord role sync originally, but that's slightly misleading.
-There is no second copy of the Discord team roles in the database that has to be synchronized.
+The useful part of this isn't really Discord.
+It's removing a second place where the same information had to be maintained.
 
-Laravel asks Discord which roles the user currently has, keeps that result in cache and uses it for authorization.
-That's the whole point.
+Discord already knew which teams someone belonged to and which position they had in those teams.
+Laravel didn't need to own another copy of that information just to answer an authorization question.
+It only needed to consume the existing source of truth.
 
-Discord was already where we managed team membership.
-When someone joined another department or became a team lead, that role had to be changed there anyway.
-
-The backoffice was the second place that needed the same change - and it was forgotten.
-
-And that's not really specific to our team.
+The backoffice was the second place that needed every team change - and it was forgotten.
+That's not really specific to our team either.
 If you maintain the same roles and permissions manually in two different systems, one of them will eventually be forgotten or drift out of sync.
-That's the whole reason companies centralize this stuff with Active Directory, Entra ID, LDAP or similar systems.
+That's why companies centralize this stuff with Active Directory, Entra ID, LDAP or similar systems instead of asking every application to maintain its own organizational structure.
+
+And the same idea applies outside of Discord.
+If another system already owns the information your Laravel application needs for an authorization decision, it can often be better to consume that information than to create another model, another admin UI and another process that has to stay synchronized.
 
 So instead of trying to become better at maintaining duplicate data, I removed the duplicate source of truth.
 

--- a/content/collections/posts/2023-08-14.seamless-role-management-with-discord.md
+++ b/content/collections/posts/2023-08-14.seamless-role-management-with-discord.md
@@ -7,7 +7,7 @@ categories:
     - tips+tricks
 image: posts/2023-08-14.seamless-role-management-with-discord.jpg
 author: gummibeer
-description: 'How I made Discord the source of truth for our Laravel Nova permissions instead of maintaining the same team roles twice.'
+description: 'How I made Discord the source of truth for our Laravel permissions instead of maintaining the same team roles twice.'
 ---
 
 When I built this, we were a team of around 30 people managing a FiveM GTA:RP server.
@@ -16,7 +16,7 @@ We had several departments and a roughly three-level hierarchy with head admins,
 Like a lot of gaming communities, Discord was our central place for communication and team management.
 So all those departments and hierarchy levels already existed as Discord roles.
 
-And then we had another set of roles for our Laravel Nova backoffice.
+And then we had another set of roles for our Laravel backoffice, which happened to be built with Nova.
 
 You can probably guess what happened.
 
@@ -135,7 +135,7 @@ Pass one role or ten roles and it returns `true` as soon as the user has one of 
 
 ## Policies stay boring
 
-With that in place there isn't anything Discord-specific left to do in Nova.
+With that in place there isn't anything special left to do in Laravel's authorization layer.
 The policies just check the roles they need:
 
 ```php
@@ -196,9 +196,9 @@ class PostPolicy
 In this example lead supporters and administrators can work with posts, but deleting one is restricted to administrators.
 Nothing unusual from Laravel's perspective.
 
-And that's also why this isn't really a Nova-specific solution.
-Nova happened to be the backoffice we used, but the authorization is implemented with normal Laravel policies and gates.
-If your backoffice uses those too - Filament or something custom for example - the same approach works there as well.
+Our backoffice happened to use Nova, so that's where I used this first.
+But nothing about the approach depends on Nova. The authorization is implemented with normal Laravel policies and gates.
+If you're using Filament, another admin panel or something custom on top of Laravel's authorization layer, the same idea applies there as well.
 
 ## It's not really a sync
 

--- a/content/collections/posts/2023-08-14.seamless-role-management-with-discord.md
+++ b/content/collections/posts/2023-08-14.seamless-role-management-with-discord.md
@@ -87,10 +87,12 @@ public function getDiscordRolesAttribute(): Collection
     }
 
     return rescue(
-        callback: fn () => Cache::swr(
+        callback: fn () => Cache::flexible(
             key: $this->getCacheKey('discord_roles'),
-            tts: CarbonInterval::minute()->totalSeconds,
-            ttl: CarbonInterval::day()->totalSeconds,
+            ttl: [
+                CarbonInterval::minute()->totalSeconds,
+                CarbonInterval::day()->totalSeconds,
+            ],
             callback: function (): Collection {
                 $member = app(DiscordConnector::class)->guild()->getGuildMember(
                     guildId: new Snowflake(config('services.discord.guild_id')),

--- a/content/collections/posts/2023-08-14.seamless-role-management-with-discord.md
+++ b/content/collections/posts/2023-08-14.seamless-role-management-with-discord.md
@@ -22,22 +22,18 @@ You can probably guess what happened.
 
 Someone changed departments, got promoted or left a team, the Discord roles were updated and the backoffice was forgotten.
 Or the other way around.
-Two places describing the same thing will eventually get out of sync.
+Two places describing the same thing will get out of sync.
 
-So I stopped trying to keep both role systems synchronized and made Discord the source of truth for the permissions in Laravel instead.
+So I stopped trying to keep both role systems synchronized manually and made Discord the source of truth for the permissions in Laravel instead.
 
 ## Discord is the source of truth
 
 I don't need every role from our Discord server inside Laravel.
 There are plenty of roles that are only relevant for Discord itself.
 
-The roles the application actually cares about are defined in a backed enum:
+The roles the application actually cares about are defined in an enum:
 
 ```php
-<?php
-
-namespace App\Enums;
-
 enum DiscordRole: string
 {
     case LEAD_ADMINISTRATOR = '100000000000000001';
@@ -117,8 +113,8 @@ public function hasDiscordRole(DiscordRole ...$roles): bool
 }
 ```
 
-The `DiscordConnector` in that snippet comes from [my Discord SDK](https://github.com/Astrotomic/discord-sdk).
-It wraps Discord's HTTP API and is built on top of Saloon, so for this use case I can simply fetch the guild member without having to run a websocket client.
+The `DiscordConnector` in that snippet comes from [my Discord SDK](https://github.com/Astrotomic/discord-sdk) package.
+It wraps Discord's HTTP API and is built on top of [Saloon](https://docs.saloon.dev), so for this use case I can simply fetch the guild member without having to run a websocket client.
 
 There are a few details in there that matter.
 
@@ -142,10 +138,6 @@ With that in place there isn't anything special left to do in Laravel's authoriz
 The policies just check the roles they need:
 
 ```php
-<?php
-
-namespace App\Policies;
-
 use App\Enums\DiscordRole;
 use App\Models\Post;
 use App\Models\User as AuthUser;
@@ -153,8 +145,6 @@ use Illuminate\Auth\Access\HandlesAuthorization;
 
 class PostPolicy
 {
-    use HandlesAuthorization;
-
     public function viewAny(AuthUser $auth): bool
     {
         return $auth->hasDiscordRole(
@@ -163,29 +153,7 @@ class PostPolicy
         );
     }
 
-    public function view(AuthUser $auth, Post $post): bool
-    {
-        return $auth->hasDiscordRole(
-            DiscordRole::LEAD_SUPPORTER,
-            DiscordRole::ADMINISTRATOR,
-        );
-    }
-
-    public function create(AuthUser $auth): bool
-    {
-        return $auth->hasDiscordRole(
-            DiscordRole::LEAD_SUPPORTER,
-            DiscordRole::ADMINISTRATOR,
-        );
-    }
-
-    public function update(AuthUser $auth, Post $post): bool
-    {
-        return $auth->hasDiscordRole(
-            DiscordRole::LEAD_SUPPORTER,
-            DiscordRole::ADMINISTRATOR,
-        );
-    }
+    // ... other methods
 
     public function delete(AuthUser $auth, Post $post): bool
     {


### PR DESCRIPTION
Rewrites the 2023 Discord role management post around the actual implementation and current site voice.

- makes Discord the explicit source of truth instead of describing this as a role sync
- restores the full anonymized `DiscordRole` enum example
- includes the full user role lookup/cache helper
- includes the complete example policy
- explains the cache/fail-closed behavior and the Nova/Filament portability
- clarifies why maintaining the same permissions manually in two systems will drift out of sync