### PR TITLE
FUCK DARK MODE

### DIFF
--- a/content/collections/pages/me.md
+++ b/content/collections/pages/me.md
@@ -9,7 +9,7 @@ template: pages/home
 
 **Web <span class="text-brand">Developer</span>, <span class="text-brand">Biker</span> and <span class="text-brand">Gamer</span> living in Hamburg, Germany**
 
-Moin <small class="text-snow-20 dark:text-snow-10">north-german greeting</small>,  
+Moin <small class="text-snow-20">north-german greeting</small>,  
 I'm a mid-twenty enthusiastic web developer and free time gamer from Hamburg, Germany. My core programming language is PHP but also a bit JavaScript if I feel the need.
 
 In my free time I try to create simple games with JavaScript or Unity3D and join the GameJams at InnoGames in Hamburg. I'm also interested in mountain biking and long distance rides.

--- a/content/collections/posts/2021-01-09.static-search-with-fusejs.md
+++ b/content/collections/posts/2021-01-09.static-search-with-fusejs.md
@@ -148,14 +148,14 @@ And the HTML part using this JavaScript object as Alpine.js data.
         autocomplete="off"
         @input.debounce.250ms="search"
         x-model="query"
-        class="w-full rounded-1 border-b-2 border-night-10 bg-white px-4 py-2 shadow focus:border-brand focus:outline-none dark:border-snow-10 dark:bg-night-10"
+        class="w-full rounded-1 border-b-2 border-night-10 bg-white px-4 py-2 shadow focus:border-brand focus:outline-none"
     />
     <ol
         class="list-none space-y-2"
         :class="{'hidden': results.length == 0}"
     >
         <template x-for="result in results">
-            <li class="overflow-hidden rounded-1 bg-white p-4 shadow dark:bg-night-20">
+            <li class="overflow-hidden rounded-1 bg-white p-4 shadow">
                 <a
                     :href="result.url"
                     class="group block"
@@ -165,7 +165,7 @@ And the HTML part using this JavaScript object as Alpine.js data.
                             x-text="result.title"
                             class="group-hover:text-brand"
                         ></strong>
-                        <span class="text-snow-20 dark:text-snow-10">
+                        <span class="text-snow-20">
                             <x-icon class="fal fa-calendar mr-1" />
                             <time x-text="result.date"></time>
                         </span>

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -3,7 +3,6 @@
 @import '@fontsource-variable/fira-code';
 @import '@fontsource/permanent-marker/400.css';
 @import 'prism-themes/themes/prism-material-light.css';
-@import 'prism-themes/themes/prism-material-dark.css' (prefers-color-scheme: dark);
 
 @plugin '@tailwindcss/typography';
 
@@ -22,8 +21,7 @@
     --color-night-10: #12152b;
     --color-night-0: #161b2a;
 
-    --shadow-light: rgb(184 194 215 / 25%) 0 4px 6px, rgb(184 194 215 / 10%) 0 5px 7px;
-    --shadow-dark: rgb(15 17 21 / 25%) 0 4px 6px, rgb(15 17 21 / 10%) 0 5px 7px;
+    --shadow: rgb(184 194 215 / 25%) 0 4px 6px, rgb(184 194 215 / 10%) 0 5px 7px;
 
     --radius-0: 0;
     --radius-1: 0.25rem;
@@ -39,7 +37,6 @@
     --container-2xl: 42rem;
 }
 
-@custom-variant light (@media (prefers-color-scheme: light));
 @custom-variant print (@media print);
 
 @utility list-square {
@@ -91,12 +88,6 @@
     margin-block: 0.25em;
 }
 
-@media (prefers-color-scheme: dark) {
-    .prose :where(ul > li)::marker {
-        color: var(--color-snow-0);
-    }
-}
-
 .markdown {
     & a[href]:not([class]) {
         @apply border-b-2 border-dashed border-brand;
@@ -131,13 +122,6 @@
         & li:not([class]) {
             @apply mb-2;
         }
-    }
-}
-
-@media (prefers-color-scheme: dark) {
-    .markdown h1:not([class]),
-    .markdown h2:not([class]) {
-        @apply text-white;
     }
 }
 
@@ -199,13 +183,7 @@ img.emoji {
 }
 
 .shadow {
-    box-shadow: var(--shadow-light);
-}
-
-@media (prefers-color-scheme: dark) {
-    .shadow {
-        box-shadow: var(--shadow-dark);
-    }
+    box-shadow: var(--shadow);
 }
 
 .hover\:underlined {
@@ -240,16 +218,6 @@ img.emoji {
     background-size: 10px 10px;
     background-repeat: repeat;
     background-image: radial-gradient(rgb(0 0 0 / 25%) 1px, transparent 1px);
-}
-
-@media (prefers-color-scheme: dark) {
-    .bg-dotted {
-        background-image: radial-gradient(rgb(255 255 255 / 25%) 0.5px, transparent 0.5px);
-    }
-
-    .bg-dotted-lg {
-        background-image: radial-gradient(rgb(255 255 255 / 25%) 1px, transparent 1px);
-    }
 }
 
 a[href] {

--- a/resources/views/components/blog/entries.blade.php
+++ b/resources/views/components/blog/entries.blade.php
@@ -10,7 +10,7 @@
     @endpush
 
     <x-section>
-        <h1 class="mb-8 text-6xl leading-none font-black text-night-0 dark:text-white">Blog</h1>
+        <h1 class="mb-8 text-6xl leading-none font-black text-night-0">Blog</h1>
         <x-post.search />
         <div class="mb-8 grid grid-flow-row grid-cols-1 gap-4 md:grid-cols-2 md:gap-8 lg:grid-cols-3 lg:gap-10 xl:gap-12">
             @foreach ($entries as $entry)

--- a/resources/views/components/charity/organizations.blade.php
+++ b/resources/views/components/charity/organizations.blade.php
@@ -5,7 +5,7 @@
     <x-section class="bg-dotted">
         <x-grid class="xl:grid-cols-4">
             @foreach ($charities as $charity)
-                <div class="overflow-hidden rounded-4 bg-white shadow dark:bg-night-20">
+                <div class="overflow-hidden rounded-4 bg-white shadow">
                     <a
                         href="{{ $charity->website }}"
                         target="_blank"

--- a/resources/views/components/code.blade.php
+++ b/resources/views/components/code.blade.php
@@ -4,7 +4,7 @@
 <?php /** @var string $lang */ ?>
 
 <div class="mt-4 mb-6">
-    <header class="flex space-x-2 rounded-t-2 bg-snow-10 px-4 dark:bg-night-20">
+    <header class="flex space-x-2 rounded-t-2 bg-snow-10 px-4">
         <div class="py-2 text-right text-xs leading-none font-bold uppercase">{{ $lang }}</div>
         <div class="grow truncate py-2 text-center font-mono text-xs leading-none">{{ $name }}</div>
         <button
@@ -17,7 +17,7 @@
             <span class="sr-only">copy code to clipboard</span>
         </button>
     </header>
-    <section class="rounded-b-2 border-2 border-t-0 border-snow-10 bg-white dark:border-night-20 dark:bg-night-10">
+    <section class="rounded-b-2 border-2 border-t-0 border-snow-10 bg-white">
         <pre><code class="language-{{ $lang }}">{{ $slot }}</code></pre>
     </section>
 </div>

--- a/resources/views/components/figure.blade.php
+++ b/resources/views/components/figure.blade.php
@@ -8,6 +8,6 @@
 >
     {{ $slot }}
     @if (!empty((string) $caption))
-        <figcaption class="mt-1 text-center text-sm text-snow-20 dark:text-snow-10">{!! \Statamic\Facades\Markdown::parse((string) $caption) !!}</figcaption>
+        <figcaption class="mt-1 text-center text-sm text-snow-20">{!! \Statamic\Facades\Markdown::parse((string) $caption) !!}</figcaption>
     @endif
 </figure>

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,6 +1,6 @@
 @props (['identity'])
 
-<footer class="w-full bg-white px-4 py-4 text-snow-20 md:px-8 md:py-6 lg:px-10 xl:px-12 dark:bg-night-10 dark:text-snow-10">
+<footer class="w-full bg-white px-4 py-4 text-snow-20 md:px-8 md:py-6 lg:px-10 xl:px-12">
     <div class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:space-x-4">
         <div class="grow py-1 text-sm">&copy; Copyright {{ $identity?->copyright_since }} - {{ date('Y') }} by {{ $identity?->copyright_name }}</div>
         <ul class="list-inline flex flex-row space-x-2">

--- a/resources/views/components/home/posts.blade.php
+++ b/resources/views/components/home/posts.blade.php
@@ -11,7 +11,7 @@
 
     @if ($posts->skip(1)->isNotEmpty())
         <x-section class="bg-dotted">
-            <h2 class="mb-8 text-4xl leading-none font-bold text-night-0 dark:text-white">Latest Posts</h2>
+            <h2 class="mb-8 text-4xl leading-none font-bold text-night-0">Latest Posts</h2>
             <x-grid>
                 @foreach ($posts->skip(1) as $post)
                     <x-post.preview

--- a/resources/views/components/home/streams.blade.php
+++ b/resources/views/components/home/streams.blade.php
@@ -4,7 +4,7 @@
     as="streams"
 >
     <x-section>
-        <h2 class="mb-8 text-4xl leading-none font-bold text-night-0 dark:text-white">Latest Streams</h2>
+        <h2 class="mb-8 text-4xl leading-none font-bold text-night-0">Latest Streams</h2>
         <x-grid>
             @foreach ($streams as $stream)
                 <x-stream.preview :stream="$stream" />

--- a/resources/views/components/img.blade.php
+++ b/resources/views/components/img.blade.php
@@ -14,6 +14,6 @@
         @if ($width) width="{{ $width }}" @endif
         @if ($height) height="{{ $height }}" @endif
         loading="lazy"
-        {{ $attributes->merge(['class' => 'w-full h-auto dark:opacity-75 dark:hover:opacity-100 transition-opacity duration-500 ease-out']) }}
+        {{ $attributes->merge(['class' => 'w-full h-auto']) }}
     />
 </picture>

--- a/resources/views/components/menu.blade.php
+++ b/resources/views/components/menu.blade.php
@@ -1,6 +1,6 @@
 @props (['identity'])
 
-<header class="sticky top-0 right-0 left-0 z-10 bg-white shadow dark:bg-night-10">
+<header class="sticky top-0 right-0 left-0 z-10 bg-white shadow">
     <nav
         class="flex flex-col px-4 md:flex-row md:justify-between md:px-8 lg:px-10 xl:px-12"
         x-data="{ show: false }"
@@ -50,7 +50,7 @@
                 <li class="flex items-center">
                     <a
                         href="{{ $url }}"
-                        class="@if ($is_current || ($url !== '/' && $is_parent)) text-brand @else text-black dark:text-white hover:text-brand @endif block w-full px-4 py-6 text-center text-2xl leading-none font-bold md:px-3 md:text-lg lg:px-4"
+                        class="@if ($is_current || ($url !== '/' && $is_parent)) text-brand @else text-black hover:text-brand @endif block w-full px-4 py-6 text-center text-2xl leading-none font-bold md:px-3 md:text-lg lg:px-4"
                         @if ($is_current) aria-current="page" @endif
                         >{{ $title }}</a
                     >

--- a/resources/views/components/pagination.blade.php
+++ b/resources/views/components/pagination.blade.php
@@ -9,7 +9,7 @@
                 <a
                     href="{{ $paginate['prev_page'] }}"
                     rel="prev"
-                    class="inline-block h-10 w-10 rounded-full bg-white text-center leading-10 shadow hover:bg-brand hover:text-white dark:bg-night-20"
+                    class="inline-block h-10 w-10 rounded-full bg-white text-center leading-10 shadow hover:bg-brand hover:text-white"
                 >
                     <x-icon name="ski-chevron-left" />
                 </a>
@@ -23,7 +23,7 @@
                     <li>
                         <a
                             href="{{ $paginate['links']['all'][0]['url'] }}"
-                            class="inline-block h-10 w-10 rounded-full bg-white text-center leading-10 shadow hover:bg-brand hover:text-white dark:bg-night-20"
+                            class="inline-block h-10 w-10 rounded-full bg-white text-center leading-10 shadow hover:bg-brand hover:text-white"
                             >1</a
                         >
                     </li>
@@ -35,7 +35,7 @@
                     <li>
                         <a
                             href="{{ $paginate['links']['all'][$paginate['total_pages'] - 1]['url'] }}"
-                            class="inline-block h-10 w-10 rounded-full bg-white text-center leading-10 shadow hover:bg-brand hover:text-white dark:bg-night-20"
+                            class="inline-block h-10 w-10 rounded-full bg-white text-center leading-10 shadow hover:bg-brand hover:text-white"
                             >{{ $paginate['total_pages'] }}</a
                         >
                     </li>
@@ -47,7 +47,7 @@
                 <a
                     href="{{ $paginate['next_page'] }}"
                     rel="next"
-                    class="inline-block h-10 w-10 rounded-full bg-white text-center leading-10 shadow hover:bg-brand hover:text-white dark:bg-night-20"
+                    class="inline-block h-10 w-10 rounded-full bg-white text-center leading-10 shadow hover:bg-brand hover:text-white"
                 >
                     <x-icon name="ski-chevron-right" />
                 </a>

--- a/resources/views/components/portfolio/projects.blade.php
+++ b/resources/views/components/portfolio/projects.blade.php
@@ -5,7 +5,7 @@
     <x-section class="bg-dotted">
         <x-grid class="xl:grid-cols-4">
             @foreach ($projects as $project)
-                <div class="overflow-hidden rounded-4 bg-white shadow dark:bg-night-20">
+                <div class="overflow-hidden rounded-4 bg-white shadow">
                     @if ($project->image)
                         <a
                             href="{{ $project->website }}"
@@ -30,7 +30,7 @@
                         >
                             <strong>{{ $project->value('title') }}</strong>
                         </a>
-                        <p class="text-sm text-snow-20 dark:text-snow-10">{{ $project->value('description') }}</p>
+                        <p class="text-sm text-snow-20">{{ $project->value('description') }}</p>
                     </div>
                 </div>
             @endforeach

--- a/resources/views/components/post/aside.blade.php
+++ b/resources/views/components/post/aside.blade.php
@@ -2,7 +2,7 @@
 <?php /** @var Illuminate\Support\HtmlString $slot */ ?>
 <?php /** @var Statamic\Contracts\Entries\Entry $post */ ?>
 
-<aside {{ $attributes->except('post')->merge(['class' => 'text-snow-20 dark:text-snow-10']) }}>
+<aside {{ $attributes->except('post')->merge(['class' => 'text-snow-20']) }}>
     <ul class="flex list-none flex-col sm:flex-row sm:space-x-3">
         <li>
             <x-icon

--- a/resources/views/components/post/preview.blade.php
+++ b/resources/views/components/post/preview.blade.php
@@ -2,7 +2,7 @@
 <?php /** @var Illuminate\Support\HtmlString $slot */ ?>
 <?php /** @var Statamic\Contracts\Entries\Entry $post */ ?>
 
-<article {{ $attributes->except('post')->merge(['class' => 'rounded-4 shadow bg-white dark:bg-night-20 overflow-hidden']) }}>
+<article {{ $attributes->except('post')->merge(['class' => 'rounded-4 shadow bg-white overflow-hidden']) }}>
     @if ($post->image)
         <a href="{{ $post->permalink }}">
             <x-img
@@ -21,7 +21,7 @@
                 class="mb-4"
             />
         @endif
-        <h3 class="mb-4 text-2xl leading-none font-bold text-night-0 dark:text-white">
+        <h3 class="mb-4 text-2xl leading-none font-bold text-night-0">
             <a
                 href="{{ $post->permalink }}"
                 class="hover:underlined"

--- a/resources/views/components/post/promo.blade.php
+++ b/resources/views/components/post/promo.blade.php
@@ -24,7 +24,7 @@
                 class="mb-8 md:text-xl"
             />
         @endif
-        <h3 class="mb-8 text-3xl leading-none font-bold text-night-0 dark:text-white">
+        <h3 class="mb-8 text-3xl leading-none font-bold text-night-0">
             <a
                 href="{{ $post->permalink }}"
                 class="hover:underlined"

--- a/resources/views/components/post/search.blade.php
+++ b/resources/views/components/post/search.blade.php
@@ -18,11 +18,11 @@
         placeholder="Search &mldr;"
         autocomplete="off"
         minlength="3"
-        class="min-w-0 flex-1 rounded-1 border-b-2 border-night-10 bg-white px-4 py-2 shadow focus:border-brand focus:outline-none dark:border-snow-10 dark:bg-night-10"
+        class="min-w-0 flex-1 rounded-1 border-b-2 border-night-10 bg-white px-4 py-2 shadow focus:border-brand focus:outline-none"
     />
     <button
         type="submit"
-        class="rounded-1 bg-brand px-4 py-2 font-bold text-night-0 shadow transition hover:brightness-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 dark:ring-offset-night-0"
+        class="rounded-1 bg-brand px-4 py-2 font-bold text-night-0 shadow transition hover:brightness-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
     >
         Search
     </button>

--- a/resources/views/components/resume/hacktoberfest.blade.php
+++ b/resources/views/components/resume/hacktoberfest.blade.php
@@ -16,7 +16,7 @@
         </div>
         <x-grid class="xl:grid-cols-4">
             @foreach ($hacktoberfests as $hacktoberfest)
-                <div class="overflow-hidden rounded-4 bg-white shadow dark:bg-night-20">
+                <div class="overflow-hidden rounded-4 bg-white shadow">
                     <x-img
                         :src="$hacktoberfest->image"
                         width="1024"
@@ -25,7 +25,7 @@
                     />
                     <div class="px-4 py-2">
                         <strong class="block">{{ $hacktoberfest->title }}</strong>
-                        <p class="text-sm text-snow-20 dark:text-snow-10">{{ $hacktoberfest->description }}</p>
+                        <p class="text-sm text-snow-20">{{ $hacktoberfest->description }}</p>
                     </div>
                 </div>
             @endforeach

--- a/resources/views/components/resume/job.blade.php
+++ b/resources/views/components/resume/job.blade.php
@@ -1,4 +1,4 @@
-<div class="py-4 @if($job->has_end) text-snow-20 dark:text-snow-10 @endif">
+<div class="py-4 @if($job->has_end) text-snow-20 @endif">
     <div class="flex flex-row sm:items-center sm:space-x-4">
         @if ($job->logo)
             <div class="hidden h-24 w-24 sm:block">
@@ -19,7 +19,7 @@
                     <a
                         href="{{ $job->website }}"
                         target="_blank"
-                        class="inline-block p-1 text-xs text-snow-20 hover:text-brand dark:text-snow-10"
+                        class="inline-block p-1 text-xs text-snow-20 hover:text-brand"
                     >
                         {{ $job->website_host }}
                     </a>
@@ -30,7 +30,7 @@
                         -
                         <time datetime="{{ ($job->end_at ?? now())->toIso8601String() }}">{{ optional($job->end_at)->year ?? 'now' }}</time>
                     </div>
-                    <span class="text-snow-20 dark:text-snow-10">{{ Illuminate\Support\Str::money($job->salary ?? 0) }}</span>
+                    <span class="text-snow-20">{{ Illuminate\Support\Str::money($job->salary ?? 0) }}</span>
                 </aside>
             </div>
             <strong class="block @if(!$job->has_end) font-bold @else text-sm font-normal @endif">{{ $job->role }}</strong>

--- a/resources/views/components/resume/jobs.blade.php
+++ b/resources/views/components/resume/jobs.blade.php
@@ -1,6 +1,6 @@
 <x-section class="bg-dotted">
     <div class="mx-auto w-full sm:max-w-screen-sm sm:px-4 md:max-w-screen-md md:px-0 lg:max-w-screen-lg">
-        <div class="divide-y overflow-hidden rounded-4 bg-white px-4 shadow dark:bg-night-20">
+        <div class="divide-y overflow-hidden rounded-4 bg-white px-4 shadow">
             @foreach ($jobs as $job)
                 <x-resume.job :job="$job" />
             @endforeach

--- a/resources/views/components/strava/card.blade.php
+++ b/resources/views/components/strava/card.blade.php
@@ -1,13 +1,13 @@
-<div class="flex flex-row items-center space-x-4 overflow-hidden rounded-4 bg-white p-4 shadow dark:bg-night-20">
+<div class="flex flex-row items-center space-x-4 overflow-hidden rounded-4 bg-white p-4 shadow">
     <x-icon
         :name="$icon"
-        class="text-5xl text-snow-20 dark:text-snow-10"
+        class="text-5xl text-snow-20"
     />
     <div class="grow">
         <span class="block text-xl">{{ $label }}</span>
         <div>
             <strong class="font-mono text-3xl text-brand">{{ round($value) }}</strong>
-            <span class="mb-4 text-snow-20 dark:text-snow-10">{{ $unit }}</span>
+            <span class="mb-4 text-snow-20">{{ $unit }}</span>
         </div>
     </div>
 </div>

--- a/resources/views/components/stream/aside.blade.php
+++ b/resources/views/components/stream/aside.blade.php
@@ -3,7 +3,7 @@
 <?php /** @var Statamic\Contracts\Entries\Entry $stream */ ?>
 @props (['stream'])
 
-<aside {{ $attributes->merge(['class' => 'text-snow-20 dark:text-snow-10']) }}>
+<aside {{ $attributes->merge(['class' => 'text-snow-20']) }}>
     <ul class="flex list-none flex-col sm:flex-row sm:space-x-3">
         <li>
             <x-icon

--- a/resources/views/components/stream/preview.blade.php
+++ b/resources/views/components/stream/preview.blade.php
@@ -3,7 +3,7 @@
 <?php /** @var Statamic\Contracts\Entries\Entry $stream */ ?>
 @props (['stream'])
 
-<article class="overflow-hidden rounded-4 bg-white shadow dark:bg-night-20">
+<article class="overflow-hidden rounded-4 bg-white shadow">
     <a href="{{ $stream->video }}">
         <x-img
             :src="$stream->image"
@@ -20,7 +20,7 @@
             />
             <strong class="uppercase"> stream </strong>
         </div>
-        <h3 class="mb-4 text-2xl leading-none font-bold text-night-0 dark:text-white">
+        <h3 class="mb-4 text-2xl leading-none font-bold text-night-0">
             <a
                 href="{{ $stream->video }}"
                 class="hover:underlined"

--- a/resources/views/pages/blog/search.blade.php
+++ b/resources/views/pages/blog/search.blade.php
@@ -7,7 +7,7 @@
 
 @section ('content')
     <x-section>
-        <h1 class="mb-8 text-6xl leading-none font-black text-night-0 dark:text-white">Search</h1>
+        <h1 class="mb-8 text-6xl leading-none font-black text-night-0">Search</h1>
         <x-post.search />
 
         @if (request()->filled('q'))

--- a/resources/views/posts/categories/show.blade.php
+++ b/resources/views/posts/categories/show.blade.php
@@ -14,7 +14,7 @@
     @php ($posts = $entries->get())
 
     <x-section>
-        <h1 class="mb-8 text-6xl leading-none font-black text-night-0 dark:text-white">Posts about {{ str($page->title)->headline() }}</h1>
+        <h1 class="mb-8 text-6xl leading-none font-black text-night-0">Posts about {{ str($page->title)->headline() }}</h1>
         <div class="mb-8 grid grid-flow-row grid-cols-1 gap-4 md:grid-cols-2 md:gap-8 lg:grid-cols-3 lg:gap-10 xl:gap-12">
             @foreach ($posts as $post)
                 <x-post.preview :post="$post" />

--- a/resources/views/web.blade.php
+++ b/resources/views/web.blade.php
@@ -78,7 +78,7 @@
     @endif
     @stack ('head')
 </head>
-<body class="line-numbers flex min-h-dvh flex-col bg-snow-0 text-night-0 dark:bg-night-0 dark:text-snow-0">
+<body class="line-numbers flex min-h-dvh flex-col bg-snow-0 text-night-0">
     <x-menu :identity="$identity" />
 
     <main class="relative flex-1">


### PR DESCRIPTION
Dark mode is gone. Completely.

This is primarily a maintenance PR because I don't use dark mode anywhere and don't want to maintain two visual systems for no reason.

But since the PR is already called **FUCK DARK MODE**, here is the unnecessarily scientific justification for my personal vendetta.

## What changed

- remove every `dark:*` Tailwind variant from the site and content examples
- remove all `prefers-color-scheme: dark` CSS
- remove the dark Prism theme
- collapse the old light/dark shadow setup into one shadow token
- remove image opacity/hover transitions that only existed for dark mode
- remove the unused light color-scheme variant as well

There was no theme toggle or persisted preference logic in JS, so there is nothing left to maintain there either.

## SCIENCE, BITCH

Turns out "dark mode is easier on the eyes" is not nearly as universal as people like to repeat it.

### Light mode can be more readable

Buchner & Baumgartner (2007) ran a series of proofreading experiments and consistently found better performance with **dark text on a light background** than light text on dark. The advantage held under both darkness and normal office lighting.

https://doi.org/10.1080/00140130701306413

Piepenbrock et al. (2013) tested both younger and older adults. Positive polarity - dark text on light background - produced better visual acuity and proofreading performance in **both age groups**. Their practitioner recommendation is basically: use positive polarity regardless of age.

https://doi.org/10.1080/00140139.2013.790485

Piepenbrock, Mayr & Buchner (2014) then looked at *why*. Positive polarity produced smaller pupils and better proofreading performance, consistent with the idea that a brighter background constricts the pupil and gives a sharper retinal image.

https://doi.org/10.1080/00140139.2014.948496

### Dark mode gets worse when text gets small

Another 2014 study by Piepenbrock, Mayr & Buchner tested text at 8, 10, 12 and 14pt. The positive-polarity advantage became **larger as character size decreased**.

Their conclusion is wonderfully direct: especially with small font sizes, negative-polarity displays should be avoided.

https://doi.org/10.1177/0018720813515509

Which is mildly relevant to a website containing code, metadata, captions, timestamps and all the other small UI text people apparently enjoy rendering as glowing grey fuzz on nearly-black backgrounds.

### Even in the dark, dark mode doesn't automatically win

Dobres et al. (2017) tested glance-like reading under daylight-like and near-dark ambient illumination. White-on-black text had the **worst legibility thresholds under dark ambient illumination**, while positive polarity remained more legible.

https://doi.org/10.1016/j.apergo.2016.11.001

So the argument "but dark mode is obviously better in a dark room" is, at minimum, not obvious.

### More recent research still doesn't give dark mode a free pass

A 2022/2023 Ergonomics study literally titled *Dark mode vogue: Do light-on-dark displays have measurable benefits to users?* looked at cognitive load, age and ambient light.

Negative polarity produced higher cognitive load for older adults in bright conditions and for younger adults in dim conditions. Younger participants liked dark mode more in dim environments, but the authors explicitly distinguish that aesthetic preference from measurable physiological benefit.

https://doi.org/10.1080/00140139.2022.2160879

So yes: sometimes people like dark mode because it looks cool.

That's allowed.

It still doesn't mean I need to maintain it.

### And the battery argument is much less exciting than advertised

Dark mode can save power on OLED screens. That's real.

But a Purdue study measuring modern OLED smartphones found that under typical indoor auto-brightness levels, switching from light to dark mode saved roughly **3-9% of total phone power** on average. The huge savings only appeared at very high screen brightness.

https://doi.org/10.1145/3458864.3467682

Also: this is a website, not an Android system UI running eight hours per day on a Pixel at 100% brightness.

## The annoying caveat because science ruins a perfectly good rant

There *is* research showing dark mode can reduce objective measures of visual fatigue at night under low screen luminance and low ambient illumination.

For example, a 2021 IEEE Access study found lower objective visual fatigue in dark mode under those specific night-time conditions - while participants still reported lower subjective fatigue and higher preference in light mode.

https://doi.org/10.1109/ACCESS.2021.3061770

So no, this PR is not claiming that dark mode is medically harmful, universally unreadable or literally useless.

It has use cases.

I just don't use them.

And maintaining an entire second color system for a feature I personally hate, don't use and don't want on my personal website is bullshit.

Hence:

# FUCK DARK MODE