### PR TITLE
Rewrite preserving date integrity post

### DIFF
--- a/content/collections/posts/2023-08-09.preserving-date-integrity.md
+++ b/content/collections/posts/2023-08-09.preserving-date-integrity.md
@@ -7,32 +7,31 @@ categories:
     - tips+tricks
 image: posts/2023-08-09.preserving-date-integrity.jpg
 author: gummibeer
-description: "Discover the power of Immutable Carbon. Learn how to safeguard date integrity, prevent accidental mutations, and enhance the reliability of your application's date handling."
+description: 'Carbon is mutable by default, which means a harmless-looking date calculation can silently change the original value. This is why I prefer CarbonImmutable for dates I pass around application code.'
 ---
 
-In the realm of PHP and Laravel, the `nesbot/carbon` package has become the go-to solution for handling date and time manipulations.
-With its powerful API, it provides developers with an intuitive way to work with dates.
-However, one crucial aspect that often goes unnoticed is the mutability of the default `Carbon` object.
-In this blog post, we will explore why adopting the `CarbonImmutable` object is a wise choice, especially when dealing with the Laravel framework, and how it can safeguard your application from unintended side effects.
+Carbon is great. But there is one default I really don't like: `Carbon` is mutable.
 
-## Understanding Mutability
+That sounds harmless until a method like `->addDay()` appears in code that only looks like a calculation. It doesn't create a changed copy. It changes the object you called it on.
 
-The default `Carbon` object in PHP is mutable, meaning that any changes made to a `Carbon` instance will directly modify the object.
-For instance, calling `->addDay()` on a `Carbon` object alters its value, which might lead to undesired results if not used with caution.
+```php
+use Carbon\Carbon;
 
-## The Importance of Immutability
+$publishedAt = Carbon::parse('2023-08-09 12:00:00');
+$expiresAt = $publishedAt->addDay();
 
-By contrast, the `CarbonImmutable` object maintains data integrity by preventing changes to the original object.
-When you use the `CarbonImmutable` object, a new instance is created with the updated value, leaving the original object unchanged.
-Embracing immutability ensures consistency and predictability in your application's codebase, making it easier to debug and maintain.
+// Both now point to 2023-08-10 12:00:00.
+dump($publishedAt->toDateTimeString());
+dump($expiresAt->toDateTimeString());
+```
 
-## Accidental Attribute Mutation
+Sometimes that is exactly what you want. Most of the time, especially once a date is passed around as application state, I don't want a random calculation to also mutate the original value.
 
-Consider a scenario where a DTO has a `published_at` property.
-If the default mutable `Carbon` is used to set the `published_at` property, all changes will propagate throughout the application, affecting other parts of the codebase and potentially leading to inconsistencies.
+## `readonly` doesn't save you
 
-Let's dive deeper into some code examples using a `Post` DTO with a `published_at` attribute and a computed attribute `is_new` to illustrate the potential accidental manipulation of the `published_at` attribute.
-Assuming you have a `posts` table in your database with a `published_at` column, let's define the `Post` model and set up the casting for the `published_at` attribute:
+This gets especially easy to miss with DTOs and value objects.
+
+Take a small `Post` DTO with a `published_at` date and a computed `is_new()` method. A post is new while its publication date is within the last 24 hours:
 
 ```php
 use Carbon\Carbon;
@@ -50,13 +49,17 @@ class Post
 }
 ```
 
-The `->addDay()` call manipulates the original `published_at` property every time you check if the post is new.
-This will always change the check itself - as the date moves.
+At first glance this looks fine. The property is even `readonly`.
 
-## Safeguarding Data Integrity
+But `readonly` only prevents replacing the object stored in the property. It doesn't make that object immutable.
 
-To avoid accidental attribute mutations, it is advisable to use the `CarbonImmutable` object when working with dates.
-This ensures that any modifications made to the `published_at` property, for instance, result in a new Carbon instance, preserving the original data.
+So every call to `is_new()` moves `published_at` one day into the future. A method that should only answer a question changes the state of the object while doing so.
+
+That's the kind of bug I don't want to debug.
+
+## Use `CarbonImmutable`
+
+The fix is boring, which is exactly what I want here: use `CarbonImmutable` instead.
 
 ```php
 use Carbon\CarbonImmutable;
@@ -74,41 +77,41 @@ class Post
 }
 ```
 
-This will ensure that the `published_at` property is really readonly and will never change it's inner value.
+The code inside `is_new()` stays exactly the same. The important difference is that `->addDay()` now returns a new instance and leaves `published_at` untouched.
 
-## Preventing Accidental Database Persistence
+Now the property behaves the way `readonly` makes it look: the date really doesn't change.
 
-Using the mutable `Carbon` object without caution could lead to inadvertent changes being persisted in the database, causing discrepancies in your data.
-By employing the `CarbonImmutable` object, you mitigate the risk of accidentally persisting unwanted changes, as the original data remains untouched.
+## Hidden mutation gets worse around persistence
 
-## Handling external Carbon objects
+Mutable dates become even more annoying once the object is part of state that may later be persisted.
 
-When working with external code that provides a `CarbonInterface` or `Carbon` object, ensuring immutability might seem challenging at first glance.
-However, achieving an immutable Carbon instance is straightforward.
-Simply utilize the `toImmutable()` method available on the Carbon instance.
-For instance:
+The line mutating the date and the line saving that state don't have to be anywhere near each other. A helper can change a date during a calculation, the mutated object can continue through the application, and some later code can write that value back to the database.
+
+That is the part I dislike most about mutable date objects: the mutation is implicit. There is no assignment that tells me, "this date changes now".
+
+With `CarbonImmutable`, that whole class of bug disappears. If I want to persist a changed date, I have to explicitly use the new instance.
+
+## Handling Carbon objects from external code
+
+Of course I don't control every date object in an application. A package can return `CarbonInterface`, and that concrete instance may still be mutable.
+
+In that case I convert it at the boundary:
 
 ```php
-use Carbon\CarbonInterface;
 use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
 
-// Assume you receive a CarbonInterface instance from an external source
 /** @var CarbonInterface $externalCarbon */
 $externalCarbon = SomeExternalPackage::getCarbonInstance();
 
-// Convert the received Carbon instance to an immutable one
 $immutableCarbon = $externalCarbon->toImmutable();
-// or
-$immutableCarbon = CarbonImmutable::instance($externalCarbon);
 
+// Or explicitly through CarbonImmutable itself.
+$immutableCarbon = CarbonImmutable::instance($externalCarbon);
 ```
 
-By calling the `toImmutable()` method on a received `Carbon` object or using `CarbonImmutable::instance()`, you create a new instance that preserves the original data while ensuring immutability.
-This approach empowers you to maintain data integrity and avoid unintended changes throughout your application.
+Both give me an immutable instance I can safely pass further into my own code.
 
-## Conclusion
+For me, that's the useful rule: I don't care whether some package prefers mutable Carbon internally. Once the date enters my application code, I want it immutable unless I have a very specific reason not to.
 
-The `nesbot/carbon` PHP package is an invaluable tool for managing dates and times in applications.
-By embracing the `CarbonImmutable` object, you can enhance data integrity and avoid unintentional mutations, safeguarding the consistency of your application.
-Employing this approach throughout your codebase ensures better maintainability and reduces the likelihood of encountering data-related issues in the future.
-Remember, using the right practices from the outset can save hours of debugging and help create a more robust and reliable application.
+If you're using Laravel, this can also be configured globally instead of handling it per callsite. I cover that in my follow-up about [using `CarbonImmutable` throughout Laravel](/blog/2023/carbon-techniques-in-laravel/).


### PR DESCRIPTION
## What changed

- rewrite the original Carbon immutability post in the current gummibeer.dev writing style
- replace the generic AI-style introduction and conclusion with a concrete developer-focused explanation
- add a small mutable Carbon example before the DTO example
- explain why PHP `readonly` does not make a mutable Carbon instance immutable
- keep the `CarbonImmutable`, `toImmutable()`, and `CarbonImmutable::instance()` examples
- tighten the persistence wording so it describes the real hidden-mutation risk without overstating Eloquent's built-in datetime cast behavior
- add a link to the Laravel-specific follow-up post

The original argument stays the same: mutable dates are easy to change accidentally, so I prefer immutable date objects throughout application code.