### PR TITLE
Widen content containers on large screens

### DIFF
--- a/resources/views/components/article.blade.php
+++ b/resources/views/components/article.blade.php
@@ -1,4 +1,4 @@
 <?php /** @var Illuminate\View\ComponentAttributeBag $attributes */ ?>
 <?php /** @var Illuminate\Support\HtmlString $slot */ ?>
 
-<article {{ $attributes->merge(['class' => 'py-8 px-4 md:px-0 mx-auto w-full sm:max-w-screen-sm md:max-w-screen-md']) }}>{{ $slot }}</article>
+<article {{ $attributes->merge(['class' => 'py-8 px-4 md:px-0 mx-auto w-full sm:max-w-screen-sm md:max-w-screen-md lg:max-w-screen-lg']) }}>{{ $slot }}</article>

--- a/resources/views/components/resume/hacktoberfest.blade.php
+++ b/resources/views/components/resume/hacktoberfest.blade.php
@@ -3,7 +3,7 @@
     as="hacktoberfests"
 >
     <x-section>
-        <div class="mx-auto prose mb-8 w-full sm:max-w-screen-sm sm:px-4 md:prose-lg md:max-w-screen-md md:px-0 lg:prose-xl">
+        <div class="mx-auto prose mb-8 w-full sm:max-w-screen-sm sm:px-4 md:prose-lg md:max-w-screen-md md:px-0 lg:prose-xl lg:max-w-screen-lg">
             <h2>Hacktoberfest</h2>
             <p>A monthlong celebration of open source software hosted by DigitalOcean, Intel and DEV. Hacktoberfest is open to everyone in the global community. All backgrounds and skill levels are encouraged to complete the challenge.</p>
             <small class="block"

--- a/resources/views/components/resume/jobs.blade.php
+++ b/resources/views/components/resume/jobs.blade.php
@@ -1,5 +1,5 @@
 <x-section class="bg-dotted">
-    <div class="mx-auto w-full sm:max-w-screen-sm sm:px-4 md:max-w-screen-md md:px-0">
+    <div class="mx-auto w-full sm:max-w-screen-sm sm:px-4 md:max-w-screen-md md:px-0 lg:max-w-screen-lg">
         <div class="divide-y overflow-hidden rounded-4 bg-white px-4 shadow dark:bg-night-20">
             @foreach ($jobs as $job)
                 <x-resume.job :job="$job" />

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -13,7 +13,7 @@
     <x-section class="relative overflow-hidden">
         <x-svg.tire class="absolute bottom-0 left-0 -z-10 hidden max-h-full opacity-10 md:block" />
 
-        <div class="mx-auto w-full space-y-8 sm:max-w-screen-sm sm:px-4 md:max-w-screen-md md:px-0">
+        <div class="mx-auto w-full space-y-8 sm:max-w-screen-sm sm:px-4 md:max-w-screen-md md:px-0 lg:max-w-screen-lg">
             <div class="prose md:prose-lg lg:prose-xl">
                 <h2>Biking</h2>
                 <p>As a compensation to my job sitting at a desk all day long and starring on a screen - I try to ride as much bike as possible.</p>


### PR DESCRIPTION
Adds `lg:max-w-screen-lg` to every existing `sm:max-w-screen-sm` / `md:max-w-screen-md` content container chain.

Updated:
- shared article container
- home biking section
- resume jobs
- Hacktoberfest intro