### PR TITLE
Add llms.txt for AI agents

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -7,7 +7,7 @@ The primary technical topics are PHP, Laravel, PostgreSQL, geography/GIS, open s
 Content also covers personal projects, work, biking, gaming, charity, and other things Tom writes about or builds.
 Blog posts are the canonical long-form articles and include publication dates, categories, code examples, and source links where relevant.
 Recorded streams are older long-form development sessions.
-The portfolio lists projects and open-source work.
+The portfolio lists websites and projects Tom has worked on.
 
 Common agent use cases:
 - Find and cite Tom's technical articles and implementation notes.
@@ -26,11 +26,10 @@ Access and integration:
 
 ## Primary content
 
-- [Home](https://gummibeer.dev/): Overview, latest posts and streams, biking, and personal introduction.
+- [Home](https://gummibeer.dev/): Personal profile, latest posts and streams, biking, and site overview.
 - [Blog](https://gummibeer.dev/blog): Published developer and personal articles.
 - [Blog search](https://gummibeer.dev/blog/search): Search published blog content.
-- [Portfolio](https://gummibeer.dev/portfolio): Projects and open-source work.
-- [About](https://gummibeer.dev/me): Personal profile and background.
+- [Portfolio](https://gummibeer.dev/portfolio): Websites and projects Tom has worked on.
 
 ## Feeds and discovery
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,49 @@
+# gummibeer.dev
+
+> Personal website of Tom Herrmann (Gummibeer), a software engineer from Hamburg, Germany, with developer articles, projects, recorded streams, and personal content.
+
+gummibeer.dev is a public personal website and developer blog.
+The primary technical topics are PHP, Laravel, PostgreSQL, geography/GIS, open source, and web development.
+Content also covers personal projects, work, biking, gaming, charity, and other things Tom writes about or builds.
+Blog posts are the canonical long-form articles and include publication dates, categories, code examples, and source links where relevant.
+Recorded streams are older long-form development sessions.
+The portfolio lists projects and open-source work.
+
+Common agent use cases:
+- Find and cite Tom's technical articles and implementation notes.
+- Summarize a post while preserving the original context and opinions.
+- Locate posts about Laravel, PHP, PostgreSQL, geography, open source, and related development topics.
+- Find Tom's public projects, profile information, resume, tools, and setup.
+- Use the sitemap or feeds to discover published content instead of guessing URLs.
+
+Access and integration:
+- Public website content does not require authentication.
+- There is no public REST API for gummibeer.dev.
+- There is no public GraphQL API for gummibeer.dev.
+- There is currently no MCP server or dedicated agent-action API.
+- Use the public HTML pages, RSS/Atom feeds, and sitemap for machine-readable discovery.
+- There are no payment or checkout flows on this site.
+
+## Primary content
+
+- [Home](https://gummibeer.dev/): Overview, latest posts and streams, biking, and personal introduction.
+- [Blog](https://gummibeer.dev/blog): Published developer and personal articles.
+- [Blog search](https://gummibeer.dev/blog/search): Search published blog content.
+- [Portfolio](https://gummibeer.dev/portfolio): Projects and open-source work.
+- [About](https://gummibeer.dev/me): Personal profile and background.
+
+## Feeds and discovery
+
+- [Sitemap](https://gummibeer.dev/sitemap.xml): Canonical crawlable URL inventory.
+- [Blog RSS](https://gummibeer.dev/blog.rss): RSS feed for published blog posts.
+- [Blog Atom](https://gummibeer.dev/blog.atom): Atom feed for published blog posts.
+- [Robots](https://gummibeer.dev/robots.txt): Crawler policy and sitemap location.
+
+## Optional
+
+- [Uses](https://gummibeer.dev/uses): Hardware, software, and tools Tom uses.
+- [Resume](https://gummibeer.dev/resume): Public resume.
+- [Charity](https://gummibeer.dev/charity): Charity-related information and activity.
+- [Source repository](https://github.com/Gummibeer/gummibeer.dev): Source code and Markdown content for this website.
+- [X](https://x.com/devgummibeer): Tom's public X profile.
+- [Instagram](https://instagram.com/dev.gummibeer): Tom's public Instagram profile.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -14,22 +14,28 @@ Common agent use cases:
 - Summarize a post while preserving the original context and opinions.
 - Locate posts about Laravel, PHP, PostgreSQL, geography, open source, and related development topics.
 - Find Tom's public projects, profile information, resume, tools, and setup.
-- Use the sitemap or feeds to discover published content instead of guessing URLs.
+- Use the site search, sitemap, or feeds to discover published content instead of guessing URLs.
+- Propose corrections or content changes through the public GitHub repository.
 
 Access and integration:
 - Public website content does not require authentication.
 - There is no public REST API for gummibeer.dev.
 - There is no public GraphQL API for gummibeer.dev.
 - There is currently no MCP server or dedicated agent-action API.
-- Use the public HTML pages, RSS/Atom feeds, and sitemap for machine-readable discovery.
+- Use the public HTML pages, search, RSS/Atom feeds, and sitemap for discovery.
 - There are no payment or checkout flows on this site.
 
 ## Primary content
 
 - [Home](https://gummibeer.dev/): Personal profile, latest posts and streams, biking, and site overview.
 - [Blog](https://gummibeer.dev/blog): Published developer and personal articles.
-- [Blog search](https://gummibeer.dev/blog/search): Search published blog content.
 - [Portfolio](https://gummibeer.dev/portfolio): Websites and projects Tom has worked on.
+
+## Search
+
+- [Blog search](https://gummibeer.dev/blog/search): Public search for published blog content. No authentication is required.
+
+For bulk discovery, prefer the sitemap or feeds over repeated searches.
 
 ## Feeds and discovery
 
@@ -38,11 +44,20 @@ Access and integration:
 - [Blog Atom](https://gummibeer.dev/blog.atom): Atom feed for published blog posts.
 - [Robots](https://gummibeer.dev/robots.txt): Crawler policy and sitemap location.
 
+## Changing content
+
+gummibeer.dev is Git-backed. Do not attempt to modify the deployed website directly.
+
+- [Source repository](https://github.com/Gummibeer/gummibeer.dev): Canonical source for the website and its content.
+- For content corrections, additions, or code changes, create a branch and submit a pull request against `master`.
+- Blog posts live in `content/collections/posts/`.
+- Pages live in `content/collections/pages/`.
+- Keep changes focused and preserve the existing Markdown, front matter, and content structure.
+
 ## Optional
 
 - [Uses](https://gummibeer.dev/uses): Hardware, software, and tools Tom uses.
 - [Resume](https://gummibeer.dev/resume): Public resume.
 - [Charity](https://gummibeer.dev/charity): Charity-related information and activity.
-- [Source repository](https://github.com/Gummibeer/gummibeer.dev): Source code and Markdown content for this website.
 - [X](https://x.com/devgummibeer): Tom's public X profile.
 - [Instagram](https://instagram.com/dev.gummibeer): Tom's public Instagram profile.


### PR DESCRIPTION
## What changed

- add `/llms.txt` as a static public file
- describe gummibeer.dev, its main content, and common agent use cases
- document the public blog search explicitly
- explicitly document that there is no public REST/GraphQL API, auth requirement, MCP server, or payment flow
- link agents to the blog, portfolio, sitemap, RSS/Atom feeds, robots.txt, and relevant profile pages
- add instructions for changing site content through a branch + pull request on the public GitHub repository
- point agents at `content/collections/posts/` and `content/collections/pages/` for the main Markdown content
- follow the current llms.txt Markdown structure with an H1, summary blockquote, guidance, and H2 sections

## Why

orank currently reports both `llms.txt exists` and `llms.txt formatting` as failed. This addresses those two Discovery gaps without pretending the site exposes APIs or auth flows it does not have.

It also makes the useful agent paths explicit: search/read the site, or propose changes through GitHub instead of trying to modify production directly.

## Verification

The file is served from `public/llms.txt`, so it will be available at `https://gummibeer.dev/llms.txt` after deployment.

After merge/deploy, rescan with:

```bash
curl -X POST https://ora.ai/api/scan \
    -H 'Content-Type: application/json' \
    -d '{"url":"gummibeer.dev"}'
```

The live orank score cannot reflect this branch before it is deployed.