### PR TITLE
Add contact trust anchor

### DIFF
--- a/content/collections/pages/contact.md
+++ b/content/collections/pages/contact.md
@@ -17,14 +17,6 @@ For work, longer questions, private topics or anything that doesn't belong into 
 
 If it's about one of my projects, an issue or a pull request, use [GitHub](https://github.com/Gummibeer). Keeping project discussions next to the code usually makes more sense than moving them into email.
 
-## X
-
-For quick public tech conversations you can find me on [X](https://x.com/devgummibeer).
-
-## Instagram
-
-For the less code-heavy side of things, I'm also on [Instagram](https://instagram.com/dev.gummibeer).
-
 ## Phone
 
 If you already know me or the topic actually needs a call, you can reach me at [+49 162 1525105](tel:+491621525105).

--- a/content/collections/pages/contact.md
+++ b/content/collections/pages/contact.md
@@ -1,0 +1,32 @@
+---
+id: 59d4e2c2-5fea-4bda-8e27-f970ef3cd3e2
+blueprint: page
+title: Contact
+template: pages/contact
+---
+
+# Contact
+
+If you want to get in touch with me, just use the channel that fits the topic. I don't need a contact form here - these are the places where I actually read and answer messages.
+
+## Email
+
+For work, longer questions, private topics or anything that doesn't belong into a public thread, email is the best option: [dev@gummibeer.de](mailto:dev@gummibeer.de).
+
+## GitHub
+
+If it's about one of my projects, an issue or a pull request, use [GitHub](https://github.com/Gummibeer). Keeping project discussions next to the code usually makes more sense than moving them into email.
+
+## X
+
+For quick public tech conversations you can find me on [X](https://x.com/devgummibeer).
+
+## Instagram
+
+For the less code-heavy side of things, I'm also on [Instagram](https://instagram.com/dev.gummibeer).
+
+## Phone
+
+If you already know me or the topic actually needs a call, you can reach me at [+49 162 1525105](tel:+491621525105).
+
+That's it. No form, no ticket system and no message disappearing into some generic inbox.

--- a/content/globals/default/identity.yaml
+++ b/content/globals/default/identity.yaml
@@ -7,6 +7,8 @@ phone: '+49 162 1525105'
 email: dev@gummibeer.de
 github_url: 'https://github.com/Gummibeer'
 steam_url: 'https://steamcommunity.com/id/gummibeer'
+contact_label: Contact
+contact_page: 59d4e2c2-5fea-4bda-8e27-f970ef3cd3e2
 imprint_label: Imprint
 imprint_page: ac97b8bf-a8c8-4bea-9aa5-97ad478f254b
 privacy_label: Privacy

--- a/content/trees/collections/pages.yaml
+++ b/content/trees/collections/pages.yaml
@@ -7,3 +7,4 @@ tree:
   - entry: 80df7d1c-46d4-4abb-9143-129ee9b99c74
   - entry: ac97b8bf-a8c8-4bea-9aa5-97ad478f254b
   - entry: 8f57f554-8d03-4cf1-a7b8-ed3e782dc7df
+  - entry: 59d4e2c2-5fea-4bda-8e27-f970ef3cd3e2

--- a/resources/blueprints/globals/identity.yaml
+++ b/resources/blueprints/globals/identity.yaml
@@ -93,6 +93,26 @@ tabs:
         display: Legal
         fields:
           -
+            handle: contact_label
+            field:
+              type: text
+              display: 'Contact Label'
+              required: true
+              validate:
+                - required
+          -
+            handle: contact_page
+            field:
+              type: entries
+              display: 'Contact Page'
+              collections:
+                - pages
+              max_items: 1
+              mode: select
+              required: true
+              validate:
+                - required
+          -
             handle: imprint_label
             field:
               type: text

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -54,6 +54,13 @@
         <ul class="list-inline flex flex-row space-x-4 text-xs">
             <li>
                 <a
+                    href="/contact"
+                    class="hover:text-brand"
+                    >Contact</a
+                >
+            </li>
+            <li>
+                <a
                     href="{{ $identity?->imprint_page?->permalink }}"
                     class="hover:text-brand"
                     >{{ $identity?->imprint_label }}</a

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -54,9 +54,9 @@
         <ul class="list-inline flex flex-row space-x-4 text-xs">
             <li>
                 <a
-                    href="/contact"
+                    href="{{ $identity?->contact_page?->permalink }}"
                     class="hover:text-brand"
-                    >Contact</a
+                    >{{ $identity?->contact_label }}</a
                 >
             </li>
             <li>

--- a/resources/views/pages/contact.blade.php
+++ b/resources/views/pages/contact.blade.php
@@ -1,0 +1,5 @@
+@extends ('web')
+
+@section ('content')
+    <x-article class="prose md:prose-lg lg:prose-xl"> {!! $content !!} </x-article>
+@endsection


### PR DESCRIPTION
## What changed

- add a real `/contact` page to the Statamic pages collection
- keep contact limited to actual contact options; no form
- list email, GitHub, and phone with a bit of context for each
- add Contact to the identity navigation data alongside Imprint and Privacy
- link the footer through the identity contact page/label instead of a hardcoded URL
- register the page in the pages structure

## orank

This addresses the missing Contact trust-anchor page. `/about` is intentionally not added here because the existing about information is already split between the homepage and resume and is being left as-is for now.
