### PR TITLE
Add Markdown alternatives for content pages

### DIFF
--- a/app/Http/Controllers/GetMarkdownController.php
+++ b/app/Http/Controllers/GetMarkdownController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Responses\MarkdownDataResponse;
+use Statamic\Facades\Data;
+
+class GetMarkdownController
+{
+    public function __invoke(string $uri): MarkdownDataResponse
+    {
+        $uri = $uri === 'index'
+            ? '/'
+            : '/'.trim($uri, '/');
+
+        abort_unless($data = Data::findByUri($uri), 404);
+
+        return new MarkdownDataResponse($data);
+    }
+}

--- a/app/Http/Responses/MarkdownDataResponse.php
+++ b/app/Http/Responses/MarkdownDataResponse.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Responses;
+
+use Statamic\Http\Responses\DataResponse;
+
+class MarkdownDataResponse extends DataResponse
+{
+    protected function contents(): string
+    {
+        $content = trim((string) $this->data->value('content'));
+
+        if (preg_match('/^#\s+\S/', $content) === 1) {
+            return $content.PHP_EOL;
+        }
+
+        $markdown = ['# '.trim((string) $this->data->title())];
+        $description = trim((string) $this->data->value('description'));
+
+        if ($description !== '') {
+            $markdown[] = $description;
+        }
+
+        if ($content !== '') {
+            $markdown[] = $content;
+        }
+
+        return implode(PHP_EOL.PHP_EOL, $markdown).PHP_EOL;
+    }
+
+    protected function adjustResponseType(): static
+    {
+        $this->headers['Content-Type'] = 'text/markdown; charset=UTF-8';
+
+        return $this;
+    }
+
+    protected function addContentHeaders(): static
+    {
+        parent::addContentHeaders();
+
+        $this->headers['Content-Type'] = 'text/markdown; charset=UTF-8';
+        $this->headers['Link'] = sprintf(
+            '<%s>; rel="canonical"; type="text/html"',
+            $this->data->absoluteUrl(),
+        );
+
+        return $this;
+    }
+}

--- a/app/Http/Responses/MarkdownDataResponse.php
+++ b/app/Http/Responses/MarkdownDataResponse.php
@@ -2,30 +2,34 @@
 
 namespace App\Http\Responses;
 
+use Illuminate\Support\Stringable;
+use Illuminate\Support\Str;
 use Statamic\Http\Responses\DataResponse;
 
 class MarkdownDataResponse extends DataResponse
 {
     protected function contents(): string
     {
-        $content = trim((string) $this->data->value('content'));
+        $description = Str::of((string) $this->data->value('description'))->trim();
 
-        if (preg_match('/^#\s+\S/', $content) === 1) {
-            return $content.PHP_EOL;
-        }
-
-        $markdown = ['# '.trim((string) $this->data->title())];
-        $description = trim((string) $this->data->value('description'));
-
-        if ($description !== '') {
-            $markdown[] = $description;
-        }
-
-        if ($content !== '') {
-            $markdown[] = $content;
-        }
-
-        return implode(PHP_EOL.PHP_EOL, $markdown).PHP_EOL;
+        return Str::of((string) $this->data->value('content'))
+            ->trim()
+            ->unless(
+                fn (Stringable $content): bool => $content->startsWith('# '),
+                fn (Stringable $content): Stringable => Str::of((string) $this->data->title())
+                    ->trim()
+                    ->prepend('# ')
+                    ->when(
+                        $description->isNotEmpty(),
+                        fn (Stringable $markdown): Stringable => $markdown->append(PHP_EOL.PHP_EOL, $description),
+                    )
+                    ->when(
+                        $content->isNotEmpty(),
+                        fn (Stringable $markdown): Stringable => $markdown->append(PHP_EOL.PHP_EOL, $content),
+                    ),
+            )
+            ->append(PHP_EOL)
+            ->toString();
     }
 
     protected function adjustResponseType(): static

--- a/resources/views/web.blade.php
+++ b/resources/views/web.blade.php
@@ -62,6 +62,14 @@
         rel="canonical"
         href="{{ $page?->permalink ?? request()->url() }}"
     />
+    @if ($page?->permalink)
+        <link
+            rel="alternate"
+            type="text/markdown"
+            href="{{ request()->path() === '/' ? url('/index.md') : url('/'.request()->path().'.md') }}"
+            title="Markdown"
+        />
+    @endif
     @stack ('head')
 </head>
 <body class="line-numbers flex min-h-dvh flex-col bg-snow-0 text-night-0 dark:bg-night-0 dark:text-snow-0">

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Blog\Category\FeedController as CategoryFeedController;
 use App\Http\Controllers\Blog\FeedController as BlogFeedController;
+use App\Http\Controllers\GetMarkdownController;
 use App\Http\Controllers\GetSitemapController;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Route;
@@ -12,6 +13,9 @@ Route::name('blog.')->group(function (): void {
     Route::get('blog/categories/{category}.{format}', CategoryFeedController::class)->whereIn('format', ['atom', 'rss'])->name('category.feed');
 });
 
+Route::get('{uri}.md', GetMarkdownController::class)
+    ->where('uri', '.*')
+    ->name('markdown');
 Route::get('sitemap.xml', GetSitemapController::class)->name('sitemap.xml');
 
 Route::get('robots.txt', static function (): Response {


### PR DESCRIPTION
## What

- serve every routable Statamic content page as a sibling `*.md` URL
- expose the homepage as `/index.md`
- advertise Markdown variants from HTML with `rel="alternate"` and `type="text/markdown"`
- return `text/markdown; charset=UTF-8`
- point Markdown responses back to the HTML canonical via an HTTP `Link` header
- preserve Statamic draft/private/protection handling by using a dedicated `DataResponse`

## Markdown output

The response uses the actual source Markdown. If the content already starts with an H1 it is kept as-is; otherwise the content title is prepended as the H1, followed by the description and body when available.

This also guarantees `/index.md` starts with a top-level heading for the orank Markdown fallback check.

## Verification

CI should cover formatting, static analysis, route/view compilation and the normal smoke checks. The orank production rescan needs to happen after this is merged and deployed.