### PR TITLE
Add agent-friendly 404 responses

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -9,6 +9,7 @@ use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Http\Request;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -28,4 +29,22 @@ return Application::configure(basePath: dirname(__DIR__))
         $exceptions->shouldRenderJsonWhen(
             fn (Request $request) => $request->is('api/*') || $request->expectsJson(),
         );
+
+        $exceptions->render(function (NotFoundHttpException $exception, Request $request) {
+            $accept = (string) $request->header('Accept', '*/*');
+
+            if (
+                ! $request->isMethod('GET')
+                || $request->is('api/*')
+                || $request->expectsJson()
+                || (str_contains($accept, 'text/html') && ! str_contains($accept, 'text/markdown'))
+            ) {
+                return null;
+            }
+
+            return response()
+                ->view('errors.404-markdown', status: 404)
+                ->header('Content-Type', 'text/markdown; charset=UTF-8')
+                ->header('Vary', 'Accept');
+        });
     })->create();

--- a/resources/views/errors/404-markdown.blade.php
+++ b/resources/views/errors/404-markdown.blade.php
@@ -1,0 +1,7 @@
+# Not Found
+
+That page doesn't exist.
+
+- [Home]({{ url('/') }})
+- [Sitemap]({{ route('sitemap.xml') }})
+- [llms.txt]({{ url('/llms.txt') }})

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -13,12 +13,8 @@
             x-cloak
         ><code x-text="window.location"></code></pre>
 
-        <p>If the URL is correct, these should get you back on track:</p>
+        <p>If you think that the page should exist don't hesitate to contact me.</p>
 
-        <ul>
-            <li><a href="{{ url('/') }}">home page</a></li>
-            <li><a href="{{ route('sitemap.xml') }}">sitemap</a></li>
-            <li><a href="{{ url('/llms.txt') }}">llms.txt</a></li>
-        </ul>
+        <a href="{{ url('/') }}">back to home page</a>
     </x-article>
 @endsection

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -13,8 +13,12 @@
             x-cloak
         ><code x-text="window.location"></code></pre>
 
-        <p>If you think that the page should exist don't hesitate to contact me.</p>
+        <p>If the URL is correct, these should get you back on track:</p>
 
-        <a href="{{ url('/') }}">back to home page</a>
+        <ul>
+            <li><a href="{{ url('/') }}">home page</a></li>
+            <li><a href="{{ route('sitemap.xml') }}">sitemap</a></li>
+            <li><a href="{{ url('/llms.txt') }}">llms.txt</a></li>
+        </ul>
     </x-article>
 @endsection

--- a/resources/views/web.blade.php
+++ b/resources/views/web.blade.php
@@ -59,6 +59,12 @@
         href="{{ route('sitemap.xml') }}"
     />
     <link
+        rel="alternate"
+        type="text/plain"
+        href="{{ url('/llms.txt') }}"
+        title="LLMs"
+    />
+    <link
         rel="canonical"
         href="{{ $page?->permalink ?? request()->url() }}"
     />


### PR DESCRIPTION
## What changed

- keep the existing human-facing HTML 404 page unchanged
- return a short `text/markdown` 404 for non-browser GET clients and explicit Markdown requests
- keep sitemap + `llms.txt` recovery links in the Markdown 404 only
- preserve the real HTTP 404 status
- leave API and JSON error responses alone
- add `Vary: Accept` to the Markdown response
- advertise `llms.txt` in the global document `<head>`; the sitemap was already advertised there

## Verification

After deployment, verify with:

- `curl -i https://gummibeer.dev/some-path-that-does-not-exist`
- `curl -i -H 'Accept: text/markdown' https://gummibeer.dev/some-path-that-does-not-exist`
- `curl -s -o /dev/null -w '%{http_code}\n' https://gummibeer.dev/some-path-that-does-not-exist`

The last command must print `404`.

This targets Ora's **Agent-friendly 404s** check without exposing machine-oriented navigation in the visible 404 UI.