### PR TITLE
Improve Markdown access for AI agents

### DIFF
--- a/app/Http/Middleware/NegotiateMarkdown.php
+++ b/app/Http/Middleware/NegotiateMarkdown.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Http\Responses\MarkdownDataResponse;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Statamic\Facades\Data;
+use Symfony\Component\HttpFoundation\Response;
+
+class NegotiateMarkdown
+{
+    private const AI_BOT_USER_AGENTS = [
+        'GPTBot',
+        'ClaudeBot',
+        'ChatGPT-User',
+        'PerplexityBot',
+        'Google-Extended',
+        'Applebot-Extended',
+        'ora-agent',
+        'DeepSeekBot',
+    ];
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (
+            ! $request->isMethod('GET')
+            || $request->is('api/*', '*.md')
+            || $request->expectsJson()
+        ) {
+            return $next($request);
+        }
+
+        $uri = '/'.trim($request->path(), '/');
+        $data = Data::findByUri($uri);
+
+        if (! $data) {
+            return $next($request);
+        }
+
+        if ($request->wantsMarkdown() || $this->isAiBot($request)) {
+            return new MarkdownDataResponse($data);
+        }
+
+        $response = $next($request);
+        $response->setVary(array_unique([...$response->getVary(), 'Accept', 'Accept-Encoding', 'User-Agent']));
+
+        return $response;
+    }
+
+    private function isAiBot(Request $request): bool
+    {
+        return Str::contains(
+            strtolower((string) $request->userAgent()),
+            array_map('strtolower', self::AI_BOT_USER_AGENTS),
+        );
+    }
+}

--- a/app/Http/Responses/MarkdownDataResponse.php
+++ b/app/Http/Responses/MarkdownDataResponse.php
@@ -11,8 +11,7 @@ class MarkdownDataResponse extends DataResponse
     protected function contents(): string
     {
         $description = Str::of((string) $this->data->value('description'))->trim();
-
-        return Str::of((string) $this->data->value('content'))
+        $markdown = Str::of((string) $this->data->value('content'))
             ->trim()
             ->unless(
                 fn (Stringable $content): bool => $content->startsWith('# '),
@@ -27,8 +26,21 @@ class MarkdownDataResponse extends DataResponse
                         $content->isNotEmpty(),
                         fn (Stringable $markdown): Stringable => $markdown->append(PHP_EOL.PHP_EOL, $content),
                     ),
-            )
-            ->append(PHP_EOL)
+            );
+        $frontmatter = [
+            '---',
+            'title: '.$this->yamlScalar((string) $this->data->title()),
+        ];
+
+        if ($description->isNotEmpty()) {
+            $frontmatter[] = 'description: '.$this->yamlScalar($description->toString());
+        }
+
+        $frontmatter[] = 'canonical: '.$this->yamlScalar($this->data->absoluteUrl());
+        $frontmatter[] = '---';
+
+        return Str::of(implode(PHP_EOL, $frontmatter))
+            ->append(PHP_EOL.PHP_EOL, $markdown, PHP_EOL)
             ->toString();
     }
 
@@ -48,7 +60,16 @@ class MarkdownDataResponse extends DataResponse
             '<%s>; rel="canonical"; type="text/html"',
             $this->data->absoluteUrl(),
         );
+        $this->setVary(array_unique([...$this->getVary(), 'Accept', 'Accept-Encoding', 'User-Agent']));
 
         return $this;
+    }
+
+    private function yamlScalar(string $value): string
+    {
+        return json_encode(
+            $value,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+        );
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\NegotiateMarkdown;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Application;
@@ -24,6 +25,7 @@ return Application::configure(basePath: dirname(__DIR__))
             ShareErrorsFromSession::class,
             PreventRequestForgery::class,
         ]);
+        $middleware->appendToGroup('web', NegotiateMarkdown::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->shouldRenderJsonWhen(
@@ -45,6 +47,6 @@ return Application::configure(basePath: dirname(__DIR__))
             return response()
                 ->view('errors.404-markdown', status: 404)
                 ->header('Content-Type', 'text/markdown; charset=UTF-8')
-                ->header('Vary', 'Accept');
+                ->header('Vary', 'Accept, Accept-Encoding');
         });
     })->create();


### PR DESCRIPTION
## What

- add YAML frontmatter to served Markdown with `title`, optional `description`, and `canonical`
- negotiate `text/markdown` on canonical Statamic URLs when Markdown is the preferred `Accept` type
- serve the Markdown representation directly to the AI bot User-Agents probed by orank
- vary negotiable responses by `Accept`, `Accept-Encoding`, and `User-Agent` so caches cannot mix HTML, Markdown, and bot variants
- keep Markdown 404 responses consistent with the `Vary` handling

## Why

This addresses the current orank Access gaps for Markdown frontmatter metadata, acceptmarkdown.com content negotiation, and bot-UA Markdown serving.

## Verify after deploy

```bash
curl -i -H 'Accept: text/markdown' https://gummibeer.dev/
curl -i -H 'Accept: text/html' https://gummibeer.dev/
curl -i -A 'ClaudeBot/1.0' -H 'Accept: text/html' https://gummibeer.dev/
curl -i https://gummibeer.dev/index.md
```

The Markdown responses should start with `---`, return `Content-Type: text/markdown`, and include `Accept` in `Vary`. Browser HTML requests should continue returning HTML.