### PR TITLE
Fix article modified timestamp fallback

### DIFF
--- a/app/Http/Controllers/GetSitemapController.php
+++ b/app/Http/Controllers/GetSitemapController.php
@@ -23,6 +23,7 @@ class GetSitemapController
                 $sitemap->add(
                     Url::create($entry->absoluteUrl())
                         ->setChangeFrequency(Url::CHANGE_FREQUENCY_DAILY)
+                        ->setLastModificationDate($entry->last_modified_at)
                         ->setPriority(1)
                 );
             });

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,6 +7,7 @@ use App\Services\FencedCodeRenderer;
 use App\Services\ImageRenderer;
 use App\Services\ParagraphRenderer;
 use Astrotomic\Pixpipe\Manipulators\Size as PixpipeSize;
+use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Routing\Router;
@@ -59,6 +60,11 @@ class AppServiceProvider extends ServiceProvider
                 $minutes = ceil(($wordCount / $wordsPerMinute) * 2) / 2;
 
                 return max(1, $minutes);
+            },
+            'last_modified_at' => static function (EntryContract $entry, mixed $value): ?CarbonImmutable {
+                $modifiedAt = $entry->value('updated_at') ?? $entry->date() ?? filemtime($entry->path());
+
+                return CarbonImmutable::make($modifiedAt);
             },
         ]);
 

--- a/app/View/Components/Og/Article.php
+++ b/app/View/Components/Og/Article.php
@@ -24,13 +24,16 @@ class Article extends Component
     {
         $title = $this->post->value('title').' | '.$this->siteName;
         $description = (string) $this->post->value('description');
+        $modifiedAt = $this->post->value('updated_at')
+            ?? $this->post->date()?->getTimestamp()
+            ?? filemtime($this->post->path());
 
         return implode(PHP_EOL, [
             OpenGraph::article($title)
                 ->url((string) $this->post->absoluteUrl())
                 ->when($description)->description($description)
                 ->publishedAt($this->post->date())
-                ->modifiedAt(Carbon::createFromTimestampUTC(filemtime($this->post->path())))
+                ->modifiedAt(Carbon::createFromTimestampUTC($modifiedAt))
                 ->locale(str_replace('-', '_', app()->getLocale())),
             Twitter::summaryLargeImage($title)
                 ->when($description)->description($description),

--- a/app/View/Components/Og/Article.php
+++ b/app/View/Components/Og/Article.php
@@ -4,7 +4,6 @@ namespace App\View\Components\Og;
 
 use Astrotomic\OpenGraph\OpenGraph;
 use Astrotomic\OpenGraph\Twitter;
-use Carbon\Carbon;
 use Illuminate\View\Component;
 use Statamic\Contracts\Entries\Entry as EntryContract;
 
@@ -24,16 +23,13 @@ class Article extends Component
     {
         $title = $this->post->value('title').' | '.$this->siteName;
         $description = (string) $this->post->value('description');
-        $modifiedAt = $this->post->value('updated_at')
-            ?? $this->post->date()?->getTimestamp()
-            ?? filemtime($this->post->path());
 
         return implode(PHP_EOL, [
             OpenGraph::article($title)
                 ->url((string) $this->post->absoluteUrl())
                 ->when($description)->description($description)
                 ->publishedAt($this->post->date())
-                ->modifiedAt(Carbon::createFromTimestampUTC($modifiedAt))
+                ->modifiedAt($this->post->last_modified_at->toDateTime())
                 ->locale(str_replace('-', '_', app()->getLocale())),
             Twitter::summaryLargeImage($title)
                 ->when($description)->description($description),


### PR DESCRIPTION
Use Statamic's `updated_at` value for article Open Graph metadata when available, fall back to the entry date, and only use the file mtime as the final fallback.

This keeps CP edits accurate without deployments making unchanged posts look modified.