### PR TITLE
Add RFC 8288 Link response headers

### DIFF
--- a/app/Http/Middleware/AddLinkHeaders.php
+++ b/app/Http/Middleware/AddLinkHeaders.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Statamic\Facades\Data;
+use Symfony\Component\HttpFoundation\Response;
+
+class AddLinkHeaders
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        if (
+            ! $request->isMethod('GET')
+            || $request->is('api/*', '*.md')
+            || $request->expectsJson()
+        ) {
+            return $response;
+        }
+
+        $uri = '/'.trim($request->path(), '/');
+        $data = Data::findByUri($uri);
+
+        if (! $data) {
+            return $response;
+        }
+
+        $markdownUrl = $request->path() === '/'
+            ? url('/index.md')
+            : url('/'.$request->path().'.md');
+
+        $response->headers->set('Link', implode(', ', [
+            sprintf('<%s>; rel="sitemap"; type="application/xml"', route('sitemap.xml')),
+            sprintf('<%s>; rel="alternate"; type="text/plain"; title="LLMs"', url('/llms.txt')),
+            sprintf('<%s>; rel="canonical"; type="text/html"', $data->absoluteUrl()),
+            sprintf('<%s>; rel="alternate"; type="text/markdown"; title="Markdown"', $markdownUrl),
+        ]));
+
+        return $response;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\AddLinkHeaders;
 use App\Http\Middleware\NegotiateMarkdown;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
@@ -25,6 +26,7 @@ return Application::configure(basePath: dirname(__DIR__))
             ShareErrorsFromSession::class,
             PreventRequestForgery::class,
         ]);
+        $middleware->prependToGroup('web', AddLinkHeaders::class);
         $middleware->appendToGroup('web', NegotiateMarkdown::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {


### PR DESCRIPTION
## What changed

- add RFC 8288 `Link` response headers for the discovery links already exposed in `<head>`
- include sitemap, `llms.txt`, canonical HTML, and Markdown alternate links
- prepend the middleware so negotiated Markdown responses for AI agents receive the same discovery headers

## Why

orank currently reports no HTTP `Link` response headers even though the equivalent links already exist in the page head.

## Verification

- PHP syntax check passes for the new middleware