### PR TITLE
Improve homepage raw HTML content ratio

### DIFF
--- a/app/Http/Controllers/GetTireSvgController.php
+++ b/app/Http/Controllers/GetTireSvgController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Response;
+use Illuminate\View\ComponentAttributeBag;
+
+class GetTireSvgController
+{
+    public function __invoke(): Response
+    {
+        return response()->view(
+            'components.svg.tire',
+            ['attributes' => new ComponentAttributeBag],
+            200,
+            ['Content-Type' => 'image/svg+xml'],
+        );
+    }
+}

--- a/resources/views/components/post/promo.blade.php
+++ b/resources/views/components/post/promo.blade.php
@@ -24,14 +24,14 @@
                 class="mb-8 md:text-xl"
             />
         @endif
-        <h3 class="mb-8 text-3xl leading-none font-bold text-night-0 dark:text-white">
+        <h2 class="mb-8 text-3xl leading-none font-bold text-night-0 dark:text-white">
             <a
                 href="{{ $post->permalink }}"
                 class="hover:underlined"
             >
                 {{ $post->title }}
             </a>
-        </h3>
+        </h2>
         <x-post.aside
             :post="$post"
             class="mb-4"

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -16,7 +16,7 @@
             alt=""
             aria-hidden="true"
             loading="lazy"
-            class="absolute bottom-0 left-0 -z-10 hidden max-h-full opacity-10 md:block dark:invert"
+            class="absolute bottom-0 left-0 -z-10 hidden max-h-full opacity-10 md:block"
         />
 
         <div class="mx-auto w-full space-y-8 sm:max-w-screen-sm sm:px-4 md:max-w-screen-md md:px-0">

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -11,7 +11,13 @@
     <x-home.streams />
 
     <x-section class="relative overflow-hidden">
-        <x-svg.tire class="absolute bottom-0 left-0 -z-10 hidden max-h-full opacity-10 md:block" />
+        <img
+            src="{{ route('assets.tire') }}"
+            alt=""
+            aria-hidden="true"
+            loading="lazy"
+            class="absolute bottom-0 left-0 -z-10 hidden max-h-full opacity-10 md:block dark:invert"
+        />
 
         <div class="mx-auto w-full space-y-8 sm:max-w-screen-sm sm:px-4 md:max-w-screen-md md:px-0">
             <div class="prose md:prose-lg lg:prose-xl">

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,8 +4,8 @@ use App\Http\Controllers\Blog\Category\FeedController as CategoryFeedController;
 use App\Http\Controllers\Blog\FeedController as BlogFeedController;
 use App\Http\Controllers\GetMarkdownController;
 use App\Http\Controllers\GetSitemapController;
+use App\Http\Controllers\GetTireSvgController;
 use Illuminate\Support\Facades\Route;
-use Illuminate\View\ComponentAttributeBag;
 
 Route::name('blog.')->group(function (): void {
     Route::statamic('blog/search', 'pages.blog.search')->name('search');
@@ -13,12 +13,7 @@ Route::name('blog.')->group(function (): void {
     Route::get('blog/categories/{category}.{format}', CategoryFeedController::class)->whereIn('format', ['atom', 'rss'])->name('category.feed');
 });
 
-Route::get('assets/tire.svg', static fn () => response()->view(
-    'components.svg.tire',
-    ['attributes' => new ComponentAttributeBag],
-    200,
-    ['Content-Type' => 'image/svg+xml'],
-))->name('assets.tire');
+Route::get('assets/tire.svg', GetTireSvgController::class)->name('assets.tire');
 
 Route::get('{uri}.md', GetMarkdownController::class)
     ->where('uri', '.*')

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,8 +4,8 @@ use App\Http\Controllers\Blog\Category\FeedController as CategoryFeedController;
 use App\Http\Controllers\Blog\FeedController as BlogFeedController;
 use App\Http\Controllers\GetMarkdownController;
 use App\Http\Controllers\GetSitemapController;
-use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
+use Illuminate\View\ComponentAttributeBag;
 
 Route::name('blog.')->group(function (): void {
     Route::statamic('blog/search', 'pages.blog.search')->name('search');
@@ -13,8 +13,9 @@ Route::name('blog.')->group(function (): void {
     Route::get('blog/categories/{category}.{format}', CategoryFeedController::class)->whereIn('format', ['atom', 'rss'])->name('category.feed');
 });
 
-Route::get('assets/tire.svg', static fn () => response(
-    Blade::render('<x-svg.tire />'),
+Route::get('assets/tire.svg', static fn () => response()->view(
+    'components.svg.tire',
+    ['attributes' => new ComponentAttributeBag],
     200,
     ['Content-Type' => 'image/svg+xml'],
 ))->name('assets.tire');

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Blog\Category\FeedController as CategoryFeedController;
 use App\Http\Controllers\Blog\FeedController as BlogFeedController;
 use App\Http\Controllers\GetMarkdownController;
 use App\Http\Controllers\GetSitemapController;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
 
 Route::name('blog.')->group(function (): void {
@@ -11,6 +12,12 @@ Route::name('blog.')->group(function (): void {
     Route::get('blog.{format}', BlogFeedController::class)->whereIn('format', ['atom', 'rss'])->name('feed');
     Route::get('blog/categories/{category}.{format}', CategoryFeedController::class)->whereIn('format', ['atom', 'rss'])->name('category.feed');
 });
+
+Route::get('assets/tire.svg', static fn () => response(
+    Blade::render('<x-svg.tire />'),
+    200,
+    ['Content-Type' => 'image/svg+xml'],
+))->name('assets.tire');
 
 Route::get('{uri}.md', GetMarkdownController::class)
     ->where('uri', '.*')


### PR DESCRIPTION
## What

- render the featured post title as an `h2` instead of jumping straight from the homepage `h1` to an `h3`
- stop inlining the decorative tire SVG into the homepage HTML
- serve that SVG separately and keep the existing decoration as an external image
- keep the existing homepage copy untouched

## Why

orank reports 2,083 characters of raw homepage content, but only a 2.0% content ratio and an `h1` → `h3` heading jump.

The homepage already has well over the requested 500 characters of meaningful server-rendered content. The real markup problem is the decorative tire component: it contributes roughly 65 KB of SVG path data directly to every homepage response.

Externalizing that SVG removes the dominant chunk of non-content markup. Based on the current orank numbers, that should move the same 2,083 content characters from roughly 2% to above the 5% target without adding filler copy just for the scanner.