### PR TITLE
Fix Markdown fallback 500 errors

### DIFF
--- a/app/Http/Responses/MarkdownDataResponse.php
+++ b/app/Http/Responses/MarkdownDataResponse.php
@@ -60,7 +60,16 @@ class MarkdownDataResponse extends DataResponse
             '<%s>; rel="canonical"; type="text/html"',
             $this->data->absoluteUrl(),
         );
-        $this->setVary(array_unique([...$this->getVary(), 'Accept', 'Accept-Encoding', 'User-Agent']));
+        $vary = array_filter(array_map(
+            trim(...),
+            explode(',', (string) ($this->headers['Vary'] ?? '')),
+        ));
+        $this->headers['Vary'] = implode(', ', array_unique([
+            ...$vary,
+            'Accept',
+            'Accept-Encoding',
+            'User-Agent',
+        ]));
 
         return $this;
     }


### PR DESCRIPTION
## What

- stop calling Symfony response methods on Statamic's `DataResponse`
- preserve any existing `Vary` values through the response header array instead
- keep `Accept`, `Accept-Encoding`, and `User-Agent` in `Vary`

## Why

`MarkdownDataResponse::addContentHeaders()` called `setVary()` / `getVary()`, but `Statamic\Http\Responses\DataResponse` is only a `Responsable`; it is not a Symfony HTTP response and does not expose those methods.

That throws before the actual response is created, which is why routes like `/blog.md` and `/resume.md` return 500.

This keeps the intended `Vary` header without calling methods that only exist on the eventual HTTP response object.