### PR TITLE
Fix Markdown post title access

### DIFF
--- a/app/Http/Responses/MarkdownDataResponse.php
+++ b/app/Http/Responses/MarkdownDataResponse.php
@@ -10,13 +10,13 @@ class MarkdownDataResponse extends DataResponse
 {
     protected function contents(): string
     {
+        $title = Str::of((string) $this->data->value('title'))->trim();
         $description = Str::of((string) $this->data->value('description'))->trim();
         $markdown = Str::of((string) $this->data->value('content'))
             ->trim()
             ->unless(
                 fn (Stringable $content): bool => $content->startsWith('# '),
-                fn (Stringable $content): Stringable => Str::of((string) $this->data->title())
-                    ->trim()
+                fn (Stringable $content): Stringable => $title
                     ->prepend('# ')
                     ->when(
                         $description->isNotEmpty(),
@@ -29,7 +29,7 @@ class MarkdownDataResponse extends DataResponse
             );
         $frontmatter = [
             '---',
-            'title: '.$this->yamlScalar((string) $this->data->title()),
+            'title: '.$this->yamlScalar($title->toString()),
         ];
 
         if ($description->isNotEmpty()) {


### PR DESCRIPTION
## What

- read the entry title through Statamic's `value('title')` API
- reuse the resolved title for the generated H1 and YAML frontmatter
- remove both invalid `Entry::title()` calls

## Why

The previous Markdown 500 fix exposed the next exception on post entries:

`Call to undefined method Statamic\Entries\Entry::title()`

Statamic entries expose field values through `value()`. Pages worked after the response-header fix, but post Markdown responses still hit these invalid method calls.