### PR TITLE
Allow AI agent crawlers in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,27 +4,39 @@ Allow: /
 User-agent: OAI-SearchBot
 Allow: /
 
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
 User-agent: Claude-SearchBot
 Allow: /
 
 User-agent: Claude-User
 Allow: /
 
+User-agent: Google-Extended
+Allow: /
+
 User-agent: PerplexityBot
 Allow: /
 
 User-agent: GPTBot
-Disallow: /
-
-User-agent: ClaudeBot
-Disallow: /
+Allow: /
 
 User-agent: CCBot
-Disallow: /
+Allow: /
 
 User-agent: ByteSpider
-Disallow: /
+Allow: /
 
-Content-Signal: search=yes, ai-train=no
+User-agent: ora-agent
+Allow: /
+
+User-agent: DeepSeekBot
+Allow: /
+
+Content-Signal: search=yes, ai-input=yes, ai-train=no
 
 Sitemap: https://gummibeer.dev/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,42 +1,6 @@
 User-agent: *
 Allow: /
 
-User-agent: OAI-SearchBot
-Allow: /
-
-User-agent: ChatGPT-User
-Allow: /
-
-User-agent: ClaudeBot
-Allow: /
-
-User-agent: Claude-SearchBot
-Allow: /
-
-User-agent: Claude-User
-Allow: /
-
-User-agent: Google-Extended
-Allow: /
-
-User-agent: PerplexityBot
-Allow: /
-
-User-agent: GPTBot
-Allow: /
-
-User-agent: CCBot
-Allow: /
-
-User-agent: ByteSpider
-Allow: /
-
-User-agent: ora-agent
-Allow: /
-
-User-agent: DeepSeekBot
-Allow: /
-
 Content-Signal: search=yes, ai-input=yes, ai-train=no
 
 Sitemap: https://gummibeer.dev/sitemap.xml


### PR DESCRIPTION
## What

- remove all crawler-specific rules from `robots.txt`
- keep the generic `User-agent: *` + `Allow: /` policy
- add `ai-input=yes` to the Content Signal

## Why

orank reports that major AI crawlers cannot reach the homepage. The robots policy should stay generic and permissive, while the intended usage policy is expressed through Content Signals:

`search=yes, ai-input=yes, ai-train=no`