### PR TITLE
Remove comments from blog posts

### DIFF
--- a/resources/views/pages/blog/post.blade.php
+++ b/resources/views/pages/blog/post.blade.php
@@ -29,14 +29,5 @@
             <h1>{{ $page->title }}</h1>
             {!! $page->content !!}
         </main>
-        <script
-            src="https://utteranc.es/client.js"
-            repo="Gummibeer/gummibeer.de"
-            issue-term="pathname"
-            label="💬 comment"
-            theme="github-light"
-            crossorigin="anonymous"
-            async
-        ></script>
     </x-article>
 @endsection


### PR DESCRIPTION
## What
- remove Utterances from blog posts
- do not replace it with another comment system
- drop the native Statamic comments/ALTCHA implementation from this branch entirely

Comments are intentionally removed from the site altogether. There is no comment collection, form, moderation flow, CAPTCHA integration, third-party comment script, or comment-specific storage left.