### PR TITLE
Fix negotiated markdown response type

### DIFF
--- a/app/Http/Middleware/NegotiateMarkdown.php
+++ b/app/Http/Middleware/NegotiateMarkdown.php
@@ -40,7 +40,7 @@ class NegotiateMarkdown
         }
 
         if ($request->wantsMarkdown() || $this->isAiBot($request)) {
-            return new MarkdownDataResponse($data);
+            return (new MarkdownDataResponse($data))->toResponse($request);
         }
 
         $response = $next($request);


### PR DESCRIPTION
## What

- convert `MarkdownDataResponse` through its `Responsable::toResponse()` implementation before returning it from the middleware
- keep the middleware return type as the concrete Symfony response

## Why

`MarkdownDataResponse` extends Statamic's `DataResponse`, which implements Laravel's `Responsable` contract instead of extending Symfony's `Response`. Returning it directly therefore triggers a production `TypeError` before Laravel can convert it.