### PR TITLE
Use asset focal points before smart crop

### DIFF
--- a/app/View/Components/Img.php
+++ b/app/View/Components/Img.php
@@ -5,8 +5,9 @@ namespace App\View\Components;
 use Illuminate\Support\Str;
 use Illuminate\View\Component;
 use Illuminate\View\View;
-use Statamic\Assets\Asset;
+use Statamic\Contracts\Assets\Asset;
 use Statamic\Contracts\Imaging\UrlBuilder;
+use Statamic\Facades\Asset as AssetFacade;
 
 class Img extends Component
 {
@@ -17,6 +18,8 @@ class Img extends Component
     private array $params = [];
 
     private string $src;
+
+    private ?Asset $asset = null;
 
     private ?string $ratio;
 
@@ -29,7 +32,8 @@ class Img extends Component
         ?int $width = null,
         ?int $height = null,
         ?string $ratio = null,
-        bool $crop = false
+        bool $crop = false,
+        ?string $focus = null,
     ) {
         $this->urlBuilder = app(UrlBuilder::class);
         $this->ratio = $ratio;
@@ -38,6 +42,7 @@ class Img extends Component
         $this->setHeight($height);
 
         if ($src instanceof Asset) {
+            $this->asset = $src;
             $this->src = $src->id();
         } elseif (Str::startsWith($src, ['http://', 'https://'])) {
             $this->src = $src;
@@ -48,7 +53,7 @@ class Img extends Component
                 : $path;
         }
 
-        $this->setDefaultParams();
+        $this->setDefaultParams($focus);
     }
 
     public function render(): View
@@ -112,7 +117,7 @@ class Img extends Component
         return $this;
     }
 
-    protected function setDefaultParams(): void
+    protected function setDefaultParams(?string $focus = null): void
     {
         $this->params['fit'] = 'max';
 
@@ -129,9 +134,26 @@ class Img extends Component
             }
         }
 
-        if ($this->crop) {
-            $this->params['fit'] = 'smartcrop';
+        if (! $this->crop) {
+            return;
         }
+
+        if (! filled($focus)) {
+            $focus = $this->assetFocus();
+        }
+
+        $this->params['fit'] = filled($focus)
+            ? 'crop-'.$focus
+            : 'smartcrop';
+    }
+
+    private function assetFocus(): ?string
+    {
+        if ($this->asset === null && ! Str::startsWith($this->src, ['http://', 'https://'])) {
+            $this->asset = AssetFacade::find($this->src);
+        }
+
+        return $this->asset?->get('focus');
     }
 
     protected function getParams(?string $format = null): array

--- a/resources/images/charity/.meta/aufstehengegenrassismus.png.yaml
+++ b/resources/images/charity/.meta/aufstehengegenrassismus.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 115109
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/ecologi.png.yaml
+++ b/resources/images/charity/.meta/ecologi.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 40418
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/ecosia.png.yaml
+++ b/resources/images/charity/.meta/ecosia.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 58524
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/gobanyo.png.yaml
+++ b/resources/images/charity/.meta/gobanyo.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 159223
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/haema.png.yaml
+++ b/resources/images/charity/.meta/haema.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 29877
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/hamburgertierschutzverein.png.yaml
+++ b/resources/images/charity/.meta/hamburgertierschutzverein.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 143424
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/kategorie1.png.yaml
+++ b/resources/images/charity/.meta/kategorie1.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 145228
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/larabelles.png.yaml
+++ b/resources/images/charity/.meta/larabelles.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 15405
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/letsencrypt.png.yaml
+++ b/resources/images/charity/.meta/letsencrypt.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 29418
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/reforestum.png.yaml
+++ b/resources/images/charity/.meta/reforestum.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 170950
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/seashepherd.png.yaml
+++ b/resources/images/charity/.meta/seashepherd.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 63178
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/thegreatbubblebarrier.png.yaml
+++ b/resources/images/charity/.meta/thegreatbubblebarrier.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 47311
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/theoceancleanup.png.yaml
+++ b/resources/images/charity/.meta/theoceancleanup.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 25696
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/tiertafelhamburg.png.yaml
+++ b/resources/images/charity/.meta/tiertafelhamburg.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 62889
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/treeware.png.yaml
+++ b/resources/images/charity/.meta/treeware.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 56734
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/unicef.png.yaml
+++ b/resources/images/charity/.meta/unicef.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 108888
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/vivaconagua.png.yaml
+++ b/resources/images/charity/.meta/vivaconagua.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 34365
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/webwide.png.yaml
+++ b/resources/images/charity/.meta/webwide.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 22551
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/wikimedia.png.yaml
+++ b/resources/images/charity/.meta/wikimedia.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 34789
 last_modified: 1787935301
 width: 768

--- a/resources/images/charity/.meta/wwf.png.yaml
+++ b/resources/images/charity/.meta/wwf.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 35092
 last_modified: 1787935301
 width: 768

--- a/resources/images/company/.meta/absolute.png.yaml
+++ b/resources/images/company/.meta/absolute.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 25474
 last_modified: 1787935301
 width: 300

--- a/resources/images/company/.meta/astrotomic.png.yaml
+++ b/resources/images/company/.meta/astrotomic.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 25761
 last_modified: 1787935301
 width: 460

--- a/resources/images/company/.meta/elbgoods.png.yaml
+++ b/resources/images/company/.meta/elbgoods.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 5370
 last_modified: 1787935301
 width: 200

--- a/resources/images/company/.meta/even-on-sunday.png.yaml
+++ b/resources/images/company/.meta/even-on-sunday.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 6435
 last_modified: 1787935301
 width: 1136

--- a/resources/images/company/.meta/frischepost.png.yaml
+++ b/resources/images/company/.meta/frischepost.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 37150
 last_modified: 1787935301
 width: 4794

--- a/resources/images/company/.meta/hospitable.png.yaml
+++ b/resources/images/company/.meta/hospitable.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 35851
 last_modified: 1787935301
 width: 3750

--- a/resources/images/company/.meta/kraken-life.png.yaml
+++ b/resources/images/company/.meta/kraken-life.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 207961
 last_modified: 1787935301
 width: 2000

--- a/resources/images/company/.meta/medienwerft.png.yaml
+++ b/resources/images/company/.meta/medienwerft.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 11516
 last_modified: 1787935301
 width: 375

--- a/resources/images/company/.meta/spatie.png.yaml
+++ b/resources/images/company/.meta/spatie.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 1891
 last_modified: 1787935301
 width: 400

--- a/resources/images/favicons/.meta/apple-touch-icon.png.yaml
+++ b/resources/images/favicons/.meta/apple-touch-icon.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 14850
 last_modified: 1788039201
 width: 180

--- a/resources/images/favicons/.meta/favicon-16x16.png.yaml
+++ b/resources/images/favicons/.meta/favicon-16x16.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 802
 last_modified: 1788039201
 width: 16

--- a/resources/images/favicons/.meta/favicon-192x192.png.yaml
+++ b/resources/images/favicons/.meta/favicon-192x192.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 16408
 last_modified: 1788039201
 width: 192

--- a/resources/images/favicons/.meta/favicon-32x32.png.yaml
+++ b/resources/images/favicons/.meta/favicon-32x32.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 1960
 last_modified: 1787935301
 width: 32

--- a/resources/images/favicons/.meta/favicon-512x512.png.yaml
+++ b/resources/images/favicons/.meta/favicon-512x512.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 53912
 last_modified: 1788039201
 width: 512

--- a/resources/images/favicons/.meta/favicon.ico.yaml
+++ b/resources/images/favicons/.meta/favicon.ico.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 15406
 last_modified: 1788039201
 width: null

--- a/resources/images/hacktoberfest/.meta/2018.png.yaml
+++ b/resources/images/hacktoberfest/.meta/2018.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 43-50
 size: 186046
 last_modified: 1787935301
 width: 1024

--- a/resources/images/hacktoberfest/.meta/2019.png.yaml
+++ b/resources/images/hacktoberfest/.meta/2019.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 38-50
 size: 209072
 last_modified: 1787935301
 width: 1025

--- a/resources/images/hacktoberfest/.meta/2020.png.yaml
+++ b/resources/images/hacktoberfest/.meta/2020.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 45-50
 size: 229281
 last_modified: 1787935301
 width: 1024

--- a/resources/images/hacktoberfest/.meta/2021.png.yaml
+++ b/resources/images/hacktoberfest/.meta/2021.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 46-50
 size: 136252
 last_modified: 1787935301
 width: 2400

--- a/resources/images/hacktoberfest/.meta/2022.png.yaml
+++ b/resources/images/hacktoberfest/.meta/2022.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 42-50
 size: 8151480
 last_modified: 1787935301
 width: 4800

--- a/resources/images/hacktoberfest/.meta/2023.png.yaml
+++ b/resources/images/hacktoberfest/.meta/2023.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 48-50
 size: 764928
 last_modified: 1787935301
 width: 2400

--- a/resources/images/og/posts/.meta/2020-01-01.hello-world.png.yaml
+++ b/resources/images/og/posts/.meta/2020-01-01.hello-world.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 70128
 last_modified: 1788304377
 width: 2048

--- a/resources/images/og/posts/.meta/2020-12-10.human-readable-intervals.png.yaml
+++ b/resources/images/og/posts/.meta/2020-12-10.human-readable-intervals.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 82708
 last_modified: 1788304378
 width: 2048

--- a/resources/images/og/posts/.meta/2020-12-13.telegram-newsletter-command.png.yaml
+++ b/resources/images/og/posts/.meta/2020-12-13.telegram-newsletter-command.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 99424
 last_modified: 1788304378
 width: 2048

--- a/resources/images/og/posts/.meta/2020-12-17.blade-component-webmentions.png.yaml
+++ b/resources/images/og/posts/.meta/2020-12-17.blade-component-webmentions.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 102138
 last_modified: 1788304378
 width: 2048

--- a/resources/images/og/posts/.meta/2020-12-19.phpdoc-in-blade-views.png.yaml
+++ b/resources/images/og/posts/.meta/2020-12-19.phpdoc-in-blade-views.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 88361
 last_modified: 1788304379
 width: 2048

--- a/resources/images/og/posts/.meta/2021-01-05.a-recap-of-2020.png.yaml
+++ b/resources/images/og/posts/.meta/2021-01-05.a-recap-of-2020.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 84111
 last_modified: 1788304379
 width: 2048

--- a/resources/images/og/posts/.meta/2021-01-09.static-search-with-fusejs.png.yaml
+++ b/resources/images/og/posts/.meta/2021-01-09.static-search-with-fusejs.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 91778
 last_modified: 1788304379
 width: 2048

--- a/resources/images/og/posts/.meta/2021-01-20.font-optimization-with-glyphhanger.png.yaml
+++ b/resources/images/og/posts/.meta/2021-01-20.font-optimization-with-glyphhanger.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 102826
 last_modified: 1788304379
 width: 2048

--- a/resources/images/og/posts/.meta/2021-01-28.yoda.png.yaml
+++ b/resources/images/og/posts/.meta/2021-01-28.yoda.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 98397
 last_modified: 1788304380
 width: 2048

--- a/resources/images/og/posts/.meta/2022-01-13.end-of-an-era.png.yaml
+++ b/resources/images/og/posts/.meta/2022-01-13.end-of-an-era.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 73711
 last_modified: 1788304380
 width: 2048

--- a/resources/images/og/posts/.meta/2023-08-09.preserving-date-integrity.png.yaml
+++ b/resources/images/og/posts/.meta/2023-08-09.preserving-date-integrity.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 115977
 last_modified: 1788304380
 width: 2048

--- a/resources/images/og/posts/.meta/2023-08-14.seamless-role-management-with-discord.png.yaml
+++ b/resources/images/og/posts/.meta/2023-08-14.seamless-role-management-with-discord.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 128868
 last_modified: 1788304381
 width: 2048

--- a/resources/images/og/posts/.meta/2023-08-28.carbon-techniques-in-laravel.png.yaml
+++ b/resources/images/og/posts/.meta/2023-08-28.carbon-techniques-in-laravel.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 129983
 last_modified: 1788304381
 width: 2048

--- a/resources/images/og/posts/.meta/2023-08-30.dynamic-route-model-binding.png.yaml
+++ b/resources/images/og/posts/.meta/2023-08-30.dynamic-route-model-binding.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 120770
 last_modified: 1788304381
 width: 2048

--- a/resources/images/og/posts/.meta/2024-06-25.lessons-from-open-source-software.png.yaml
+++ b/resources/images/og/posts/.meta/2024-06-25.lessons-from-open-source-software.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 112364
 last_modified: 1788304381
 width: 2048

--- a/resources/images/og/posts/.meta/2024-06-28.working-at-hospitable.png.yaml
+++ b/resources/images/og/posts/.meta/2024-06-28.working-at-hospitable.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 88987
 last_modified: 1788304382
 width: 2048

--- a/resources/images/og/posts/.meta/2024-07-24.geography-in-laravel-part1.png.yaml
+++ b/resources/images/og/posts/.meta/2024-07-24.geography-in-laravel-part1.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 124902
 last_modified: 1788304382
 width: 2048

--- a/resources/images/og/posts/.meta/2026-04-24.laravel-custom-email-validation.png.yaml
+++ b/resources/images/og/posts/.meta/2026-04-24.laravel-custom-email-validation.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 98822
 last_modified: 1788304382
 width: 2048

--- a/resources/images/og/static/.meta/blog.png.yaml
+++ b/resources/images/og/static/.meta/blog.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 49559
 last_modified: 1788304383
 width: 2048

--- a/resources/images/og/static/.meta/charity.png.yaml
+++ b/resources/images/og/static/.meta/charity.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 52756
 last_modified: 1788304384
 width: 2048

--- a/resources/images/og/static/.meta/home.png.yaml
+++ b/resources/images/og/static/.meta/home.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 72704
 last_modified: 1788304385
 width: 2048

--- a/resources/images/og/static/.meta/imprint.png.yaml
+++ b/resources/images/og/static/.meta/imprint.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 47442
 last_modified: 1788304383
 width: 2048

--- a/resources/images/og/static/.meta/me.png.yaml
+++ b/resources/images/og/static/.meta/me.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 54532
 last_modified: 1788304383
 width: 2048

--- a/resources/images/og/static/.meta/portfolio.png.yaml
+++ b/resources/images/og/static/.meta/portfolio.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 52980
 last_modified: 1788304384
 width: 2048

--- a/resources/images/og/static/.meta/privacy.png.yaml
+++ b/resources/images/og/static/.meta/privacy.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 62290
 last_modified: 1788304383
 width: 2048

--- a/resources/images/og/static/.meta/resume.png.yaml
+++ b/resources/images/og/static/.meta/resume.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 53562
 last_modified: 1788304384
 width: 2048

--- a/resources/images/og/static/.meta/uses.png.yaml
+++ b/resources/images/og/static/.meta/uses.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-45
 size: 50605
 last_modified: 1788304384
 width: 2048

--- a/resources/images/portfolio/.meta/aromagran.png.yaml
+++ b/resources/images/portfolio/.meta/aromagran.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 30718
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/asprospitaki.png.yaml
+++ b/resources/images/portfolio/.meta/asprospitaki.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 135379
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/aufstehengegenrassismus.png.yaml
+++ b/resources/images/portfolio/.meta/aufstehengegenrassismus.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 115109
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/barfital.png.yaml
+++ b/resources/images/portfolio/.meta/barfital.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 85138
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/chocola.png.yaml
+++ b/resources/images/portfolio/.meta/chocola.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 13780
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/dogfit.png.yaml
+++ b/resources/images/portfolio/.meta/dogfit.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 171120
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/finanzdiskurs.png.yaml
+++ b/resources/images/portfolio/.meta/finanzdiskurs.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 29926
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/janinepantzek.png.yaml
+++ b/resources/images/portfolio/.meta/janinepantzek.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 42893
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/kategorie1.png.yaml
+++ b/resources/images/portfolio/.meta/kategorie1.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 145228
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/mareilebraun.png.yaml
+++ b/resources/images/portfolio/.meta/mareilebraun.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 27258
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/maximko.png.yaml
+++ b/resources/images/portfolio/.meta/maximko.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 32806
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/moinhund.png.yaml
+++ b/resources/images/portfolio/.meta/moinhund.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 48557
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/pandoryaphotography.png.yaml
+++ b/resources/images/portfolio/.meta/pandoryaphotography.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 17032
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/shootager.png.yaml
+++ b/resources/images/portfolio/.meta/shootager.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 26479
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/studiopolster.png.yaml
+++ b/resources/images/portfolio/.meta/studiopolster.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 34874
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/tentangli.png.yaml
+++ b/resources/images/portfolio/.meta/tentangli.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 128683
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/thenichetraveller.png.yaml
+++ b/resources/images/portfolio/.meta/thenichetraveller.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 45226
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/tierphysiotherapiehamburg.png.yaml
+++ b/resources/images/portfolio/.meta/tierphysiotherapiehamburg.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 167232
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/villapsili.png.yaml
+++ b/resources/images/portfolio/.meta/villapsili.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 71549
 last_modified: 1787935301
 width: 768

--- a/resources/images/portfolio/.meta/vivianlovasz.png.yaml
+++ b/resources/images/portfolio/.meta/vivianlovasz.png.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 57218
 last_modified: 1787935301
 width: 768

--- a/resources/images/posts/.meta/2020-01-01.hello-world.jpg.yaml
+++ b/resources/images/posts/.meta/2020-01-01.hello-world.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 84797
 last_modified: 1787935301
 width: 2400

--- a/resources/images/posts/.meta/2020-01-22.developer-courtesy.jpg.yaml
+++ b/resources/images/posts/.meta/2020-01-22.developer-courtesy.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 60-36
 size: 411407
 last_modified: 1788039201
 width: 2400

--- a/resources/images/posts/.meta/2020-12-10.human-readable-intervals.jpg.yaml
+++ b/resources/images/posts/.meta/2020-12-10.human-readable-intervals.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 55-46
 size: 511946
 last_modified: 1787935301
 width: 2400

--- a/resources/images/posts/.meta/2020-12-13.telegram-newsletter-command.jpg.yaml
+++ b/resources/images/posts/.meta/2020-12-13.telegram-newsletter-command.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 72-47
 size: 464423
 last_modified: 1787935301
 width: 2400

--- a/resources/images/posts/.meta/2020-12-17.blade-component-webmentions.jpg.yaml
+++ b/resources/images/posts/.meta/2020-12-17.blade-component-webmentions.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-48
 size: 169997
 last_modified: 1787935301
 width: 2400

--- a/resources/images/posts/.meta/2020-12-19.phpdoc-in-blade-views.jpg.yaml
+++ b/resources/images/posts/.meta/2020-12-19.phpdoc-in-blade-views.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 55-50
 size: 414484
 last_modified: 1787935301
 width: 2400

--- a/resources/images/posts/.meta/2021-01-05.a-recap-of-2020.jpg.yaml
+++ b/resources/images/posts/.meta/2021-01-05.a-recap-of-2020.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-43
 size: 626091
 last_modified: 1787935301
 width: 2400

--- a/resources/images/posts/.meta/2021-01-09.static-search-with-fusejs.jpg.yaml
+++ b/resources/images/posts/.meta/2021-01-09.static-search-with-fusejs.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 58-50
 size: 690476
 last_modified: 1787935301
 width: 2400

--- a/resources/images/posts/.meta/2021-01-13.feature-tests-are-a-waste-of-time.jpg.yaml
+++ b/resources/images/posts/.meta/2021-01-13.feature-tests-are-a-waste-of-time.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 30-58
 size: 220381
 last_modified: 1788039201
 width: 2400

--- a/resources/images/posts/.meta/2021-01-20.font-optimization-with-glyphhanger.jpg.yaml
+++ b/resources/images/posts/.meta/2021-01-20.font-optimization-with-glyphhanger.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-53
 size: 458189
 last_modified: 1787935301
 width: 2400

--- a/resources/images/posts/.meta/2022-01-13.end-of-an-era.jpg.yaml
+++ b/resources/images/posts/.meta/2022-01-13.end-of-an-era.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 48-40
 size: 825328
 last_modified: 1787935301
 width: 2400

--- a/resources/images/posts/.meta/2023-08-09.preserving-date-integrity.jpg.yaml
+++ b/resources/images/posts/.meta/2023-08-09.preserving-date-integrity.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 52-48
 size: 1128012
 last_modified: 1787935301
 width: 2400

--- a/resources/images/posts/.meta/2023-08-14.seamless-role-management-with-discord.jpg.yaml
+++ b/resources/images/posts/.meta/2023-08-14.seamless-role-management-with-discord.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 66-52
 size: 458792
 last_modified: 1787935301
 width: 2400

--- a/resources/images/posts/.meta/2023-08-28.carbon-techniques-in-laravel.jpg.yaml
+++ b/resources/images/posts/.meta/2023-08-28.carbon-techniques-in-laravel.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 52-50
 size: 301491
 last_modified: 1787935301
 width: 2400

--- a/resources/images/posts/.meta/2023-08-30.dynamic-route-model-binding.jpg.yaml
+++ b/resources/images/posts/.meta/2023-08-30.dynamic-route-model-binding.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 29-50
 size: 304429
 last_modified: 1787935301
 width: 2400

--- a/resources/images/posts/.meta/2024-06-25.lessons-from-open-source-software.jpg.yaml
+++ b/resources/images/posts/.meta/2024-06-25.lessons-from-open-source-software.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 77-43
 size: 473316
 last_modified: 1787935301
 width: 2400

--- a/resources/images/posts/.meta/2024-06-28.working-at-hospitable.jpg.yaml
+++ b/resources/images/posts/.meta/2024-06-28.working-at-hospitable.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 62-52
 size: 254021
 last_modified: 1787935301
 width: 2048

--- a/resources/images/posts/.meta/2024-07-24.geography-in-laravel-part1.jpg.yaml
+++ b/resources/images/posts/.meta/2024-07-24.geography-in-laravel-part1.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 76-42
 size: 641856
 last_modified: 1787935301
 width: 2400

--- a/resources/images/posts/.meta/2026-04-24.laravel-custom-email-validation.jpg.yaml
+++ b/resources/images/posts/.meta/2026-04-24.laravel-custom-email-validation.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 54-31
 size: 440585
 last_modified: 1788862876
 width: 2400

--- a/resources/images/posts/.meta/2026-09-08.ai-session-review-machine.jpg.yaml
+++ b/resources/images/posts/.meta/2026-09-08.ai-session-review-machine.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 63-23
 size: 407444
 last_modified: 1788863068
 width: 2400

--- a/resources/images/posts/2021-01-28.yoda/.meta/content-candle.jpg.yaml
+++ b/resources/images/posts/2021-01-28.yoda/.meta/content-candle.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 58-58
 size: 245967
 last_modified: 1788039201
 width: 2400

--- a/resources/images/posts/2021-01-28.yoda/.meta/content-mrt.jpg.yaml
+++ b/resources/images/posts/2021-01-28.yoda/.meta/content-mrt.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 68-50
 size: 190441
 last_modified: 1788039201
 width: 2048

--- a/resources/images/posts/2021-01-28.yoda/.meta/content-paw-prints.jpg.yaml
+++ b/resources/images/posts/2021-01-28.yoda/.meta/content-paw-prints.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 50-50
 size: 78753
 last_modified: 1788039201
 width: 2400

--- a/resources/images/posts/2021-01-28.yoda/.meta/header-01.jpg.yaml
+++ b/resources/images/posts/2021-01-28.yoda/.meta/header-01.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 73-64
 size: 248250
 last_modified: 1787935301
 width: 2400

--- a/resources/images/posts/2021-01-28.yoda/.meta/header-02.jpg.yaml
+++ b/resources/images/posts/2021-01-28.yoda/.meta/header-02.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 67-52
 size: 255386
 last_modified: 1787935301
 width: 2400

--- a/resources/images/posts/2021-01-28.yoda/.meta/header-03.jpg.yaml
+++ b/resources/images/posts/2021-01-28.yoda/.meta/header-03.jpg.yaml
@@ -1,4 +1,5 @@
-data: {}
+data:
+  focus: 30-63
 size: 554641
 last_modified: 1787935301
 width: 2400


### PR DESCRIPTION
Use explicit focal points first, then Statamic asset focal points, and only fall back to Pixpipe smartcrop when neither exists.

I also reviewed the existing image assets and added focal points to all 114 assets that currently have Statamic metadata. Post photos and Hacktoberfest banners use image-specific focal points; intentionally centered logos/favicons use `50-50`, and generated OG cards use `50-45`.

The existing asset focal points now handle cases where the gradient-based smart crop picked things like field markings instead of the actual subject.