### PR TITLE
Unify identity name

### DIFF
--- a/app/Services/Feed.php
+++ b/app/Services/Feed.php
@@ -31,7 +31,7 @@ final class Feed extends SpatieFeed
         }
 
         return new self(
-            $title.' | '.$identity->inCurrentSite()->get('site_name'),
+            $title.' | '.$identity->inCurrentSite()->get('name'),
             $items,
             request()->url(),
             'feed::'.$format,

--- a/app/View/Components/Og/Article.php
+++ b/app/View/Components/Og/Article.php
@@ -11,17 +11,17 @@ class Article extends Component
 {
     protected EntryContract $post;
 
-    protected string $siteName;
+    protected string $name;
 
-    public function __construct(EntryContract $post, string $siteName)
+    public function __construct(EntryContract $post, string $name)
     {
         $this->post = $post;
-        $this->siteName = $siteName;
+        $this->name = $name;
     }
 
     public function render(): string
     {
-        $title = $this->post->value('title').' | '.$this->siteName;
+        $title = $this->post->value('title').' | '.$this->name;
         $description = (string) $this->post->value('description');
 
         return implode(PHP_EOL, [

--- a/content/globals/default/identity.yaml
+++ b/content/globals/default/identity.yaml
@@ -1,7 +1,5 @@
-site_name: 'Tom Herrmann'
-brand_name: 'Tom Herrmann'
+name: 'Tom Herrmann'
 tagline: 'Developer / Biker / Gamer'
-copyright_name: 'Tom Herrmann'
 copyright_since: 2015
 phone: '+49 162 1525105'
 email: dev@gummibeer.de

--- a/resources/blueprints/globals/identity.yaml
+++ b/resources/blueprints/globals/identity.yaml
@@ -7,18 +7,10 @@ tabs:
         display: Identity
         fields:
           -
-            handle: site_name
+            handle: name
             field:
               type: text
-              display: 'Site Name'
-              required: true
-              validate:
-                - required
-          -
-            handle: brand_name
-            field:
-              type: text
-              display: 'Brand Name'
+              display: Name
               required: true
               validate:
                 - required
@@ -27,14 +19,6 @@ tabs:
             field:
               type: text
               display: Tagline
-              required: true
-              validate:
-                - required
-          -
-            handle: copyright_name
-            field:
-              type: text
-              display: 'Copyright Name'
               required: true
               validate:
                 - required

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -2,7 +2,7 @@
 
 <footer class="w-full bg-white px-4 py-4 text-snow-20 md:px-8 md:py-6 lg:px-10 xl:px-12">
     <div class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:space-x-4">
-        <div class="grow py-1 text-sm">&copy; Copyright {{ $identity?->copyright_since }} - {{ date('Y') }} by {{ $identity?->copyright_name }}</div>
+        <div class="grow py-1 text-sm">&copy; Copyright {{ $identity?->copyright_since }} - {{ date('Y') }} by {{ $identity?->name }}</div>
         <ul class="list-inline flex flex-row space-x-2">
             <li>
                 <a

--- a/resources/views/components/menu.blade.php
+++ b/resources/views/components/menu.blade.php
@@ -12,7 +12,7 @@
                     href="{{ url('/') }}"
                     class="inline-block px-0 py-4 font-logo text-2xl leading-none tracking-wider whitespace-nowrap lg:text-3xl"
                 >
-                    {{ $identity?->brand_name }}
+                    {{ $identity?->name }}
                 </a>
             </div>
 

--- a/resources/views/components/og/profile.blade.php
+++ b/resources/views/components/og/profile.blade.php
@@ -1,5 +1,5 @@
 @cascade ([
-    'site',
+    'identity',
     'page' => null,
 ])
 
@@ -9,7 +9,7 @@
 />
 <meta
     property="og:title"
-    content="{{ $page?->title ? $page->title.' | '.$site->site_name : $site->site_name }}"
+    content="{{ $page?->title ? $page->title.' | '.$identity->name : $identity->name }}"
 />
 <meta
     property="og:url"
@@ -31,7 +31,7 @@
 />
 <meta
     name="twitter:title"
-    content="{{ $page?->title ? $page->title.' | '.$site->site_name : $site->site_name }}"
+    content="{{ $page?->title ? $page->title.' | '.$identity->name : $identity->name }}"
 />
 @if ($page?->description)
     <meta

--- a/resources/views/components/og/website.blade.php
+++ b/resources/views/components/og/website.blade.php
@@ -1,5 +1,5 @@
 @cascade ([
-    'site',
+    'identity',
     'page' => null,
 ])
 
@@ -9,7 +9,7 @@
 />
 <meta
     property="og:title"
-    content="{{ $page?->title ? $page->title.' | '.$site->site_name : $site->site_name }}"
+    content="{{ $page?->title ? $page->title.' | '.$identity->name : $identity->name }}"
 />
 <meta
     property="og:url"
@@ -31,7 +31,7 @@
 />
 <meta
     name="twitter:title"
-    content="{{ $page?->title ? $page->title.' | '.$site->site_name : $site->site_name }}"
+    content="{{ $page?->title ? $page->title.' | '.$identity->name : $identity->name }}"
 />
 @if ($page?->description)
     <meta

--- a/resources/views/og/image.blade.php
+++ b/resources/views/og/image.blade.php
@@ -35,7 +35,7 @@
     style="background-image: radial-gradient(circle at 25px 25px, lightgray 2%, transparent 0%), radial-gradient(circle at 75px 75px, lightgray 2%, transparent 0%); background-size: 100px 100px"
 >
     <main class="mx-auto w-full max-w-[1800px] px-24">
-        <div class="mb-[7.5rem] font-logo text-[10rem] leading-none text-brand">{{ $identity->get('brand_name') }}</div>
+        <div class="mb-[7.5rem] font-logo text-[10rem] leading-none text-brand">{{ $identity->get('name') }}</div>
 
         <h1 class="m-0 text-[8rem] leading-[1.05] font-black text-black">{{ $title }}</h1>
 

--- a/resources/views/pages/blog/post.blade.php
+++ b/resources/views/pages/blog/post.blade.php
@@ -9,7 +9,7 @@
     />
     <x-og.article
         :post="$page"
-        :site-name="$identity->site_name"
+        :name="$identity->name"
     />
 @endpush
 

--- a/resources/views/web.blade.php
+++ b/resources/views/web.blade.php
@@ -25,7 +25,7 @@
         />
     @endif
 
-    <title>{{ $page?->title ? $page->title.' | '.($identity?->site_name ?? config('app.name')) : ($identity?->site_name ?? config('app.name')) }}</title>
+    <title>{{ $page?->title ? $page->title.' | '.($identity?->name ?? config('app.name')) : ($identity?->name ?? config('app.name')) }}</title>
     @if ($page?->description)
         <meta
             name="description"


### PR DESCRIPTION
## Summary

- replace `site_name`, `brand_name`, and `copyright_name` with a single required `name` field
- use that value for page/feed titles, menu branding, OG metadata/images, and copyright
- rename the article OG component input from `siteName` to `name`
- make the OG profile/website components explicitly cascade the `identity` global

This removes three copies of the same identity value so they cannot drift apart.