### PR TITLE
Respect DNT and document Umami analytics

### DIFF
--- a/content/collections/pages/privacy.md
+++ b/content/collections/pages/privacy.md
@@ -7,21 +7,33 @@ template: pages/privacy
 
 # Privacy Policy
 
-**Nothing.** I really collect nothing about you.
+I keep this site pretty boring from a privacy perspective. There are no accounts, no contact form and no advertising trackers.
 
-Following the GDPR (General Data Protection Regulation) I have to tell you what data is collected by pages I link to and tools I use.
+Following the GDPR (General Data Protection Regulation) I have to tell you what data is collected by this site, pages I link to and tools I use.
 
 ## Cookies
 
 Believe it or not - I do not use cookies. There is nothing I want to track with them or optimize.
 
+## Analytics
+
+I use [Umami](https://umami.is) to get basic statistics about how this site is used, like which pages are visited and where visitors came from.
+
+Umami does not use cookies. It creates a pseudonymous session identifier from technical request data such as your IP address and user agent, but does not store the IP address itself. I do not use these statistics to identify individual visitors.
+
+The tracker also respects your browser's Do Not Track (DNT) setting. If your browser sends that signal, Umami does not collect analytics for your visit.
+
+I process these statistics based on my legitimate interest in understanding how this site is used without adding advertising trackers or user profiles (Art. 6(1)(f) GDPR).
+
 ## Collection of general data and information
 
-I do not intentionally collect anything about you or your system. As with any web request, your IP address, browser version and similar technical information are transmitted to the server handling the request. Depending on the hosting setup, server logs may be created.
+As with any web request, your IP address, browser version and similar technical information are transmitted to the server handling the request. Depending on the hosting setup, server logs may be created.
+
+Outside the analytics data described above, I do not intentionally collect anything about you or your system.
 
 ## Routine erasure and blocking of personal data
 
-I do not intentionally persist personal data through this website.
+Outside the analytics data described above, I do not intentionally persist personal data through this website.
 
 ## Rights of the data subject
 
@@ -29,4 +41,4 @@ You are allowed to ask me anytime what I have saved and know about you and also 
 
 ## Linking to foreign pages
 
-Primary in the footer section but also some other places I link to other pages. I can not tell you what data they collect and what they do with them - please refer to the privacy statements of the linked page to find these information.
+Primarily in the footer section but also some other places I link to other pages. I can not tell you what data they collect and what they do with them - please refer to the privacy statements of the linked page to find these information.

--- a/resources/views/web.blade.php
+++ b/resources/views/web.blade.php
@@ -81,6 +81,7 @@
         <script
             async
             defer
+            data-do-not-track="true"
             data-website-id="5790432b-8e52-4f5d-b458-937bb1ddedc6"
             src="https://u.gummibeer.dev/script.js"
         ></script>


### PR DESCRIPTION
Adds `data-do-not-track="true"` to the Umami tracker and updates the privacy policy to describe the analytics setup accurately.

The privacy page now covers Umami's cookieless analytics, the pseudonymous session identifier, DNT handling and the legitimate-interest basis without adding a consent banner or persistent opt-out storage.