### PR TITLE
Wire generated OG images into social metadata

### DIFF
--- a/app/Console/Commands/GenerateOgImages.php
+++ b/app/Console/Commands/GenerateOgImages.php
@@ -29,7 +29,7 @@ class GenerateOgImages extends Command
                 $date = $post->date();
 
                 $this->saveImage(
-                    "images/og/posts/{$date->format('Y-m-d')}.{$post->slug()}.png",
+                    (string) $post->og_image,
                     [
                         'title' => (string) $post->value('title'),
                         'date' => $date,
@@ -46,24 +46,12 @@ class GenerateOgImages extends Command
                 $date = $post->date();
 
                 $this->saveImage(
-                    "images/og/streams/{$date->format('Y-m-d')}.{$post->slug()}.png",
+                    (string) $post->og_image,
                     [
                         'title' => (string) $post->value('title'),
                         'date' => $date,
                         'readTime' => $post->read_time,
                     ],
-                );
-            });
-
-        Entry::whereCollection('pages')
-            ->each(function (mixed $page): void {
-                if (! $page instanceof StatamicEntry || ! $page->published()) {
-                    return;
-                }
-
-                $this->saveImage(
-                    "images/og/static/{$page->slug()}.png",
-                    ['title' => (string) $page->value('title')],
                 );
             });
 
@@ -73,10 +61,23 @@ class GenerateOgImages extends Command
             throw new RuntimeException('The Statamic identity global is missing.');
         }
 
-        $this->saveImage(
-            'images/og/static/home.png',
-            ['title' => (string) $identity->inDefaultSite()->get('tagline')],
-        );
+        $identity = $identity->inDefaultSite();
+
+        Entry::whereCollection('pages')
+            ->each(function (mixed $page) use ($identity): void {
+                if (! $page instanceof StatamicEntry || ! $page->published()) {
+                    return;
+                }
+
+                $title = $page->uri() === '/'
+                    ? (string) $identity->get('tagline')
+                    : (string) $page->value('title');
+
+                $this->saveImage(
+                    (string) $page->og_image,
+                    ['title' => $title],
+                );
+            });
     }
 
     /**

--- a/app/Console/Commands/GenerateOgImages.php
+++ b/app/Console/Commands/GenerateOgImages.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Services\OpenGraphImage;
 use Carbon\CarbonInterval;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
@@ -100,7 +101,7 @@ class GenerateOgImages extends Command
 
         Browsershot::html($html)
             ->setNodeModulePath(base_path('node_modules'))
-            ->windowSize(2048, 1170)
+            ->windowSize(OpenGraphImage::WIDTH, OpenGraphImage::HEIGHT)
             ->waitForFunction('document.fonts.status === "loaded"')
             ->save($path);
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Contracts\StreamTranscriptProvider;
 use App\Http\Middleware\AutoLoginStatamicControlPanel;
 use App\Markdown\MarkdownExtension;
+use App\Services\OpenGraphImage;
 use App\Services\ReadingTime;
 use App\Services\YouTubeTranscript;
 use Astrotomic\Pixpipe\Manipulators\Size as PixpipeSize;
@@ -49,7 +50,14 @@ class AppServiceProvider extends ServiceProvider
 
     public function registerComputedContentValues(): void
     {
+        $ogImage = static fn (EntryContract $entry, mixed $value): string => (string) ($value ?? OpenGraphImage::path($entry));
+
+        StatamicCollection::computed('pages', [
+            'og_image' => $ogImage,
+        ]);
+
         StatamicCollection::computed('posts', [
+            'og_image' => $ogImage,
             'image' => static function (EntryContract $entry, mixed $value): ?string {
                 $images = $entry->value('images');
 
@@ -66,6 +74,7 @@ class AppServiceProvider extends ServiceProvider
         ]);
 
         StatamicCollection::computed('streams', [
+            'og_image' => $ogImage,
             'duration' => static fn (EntryContract $entry, mixed $value): CarbonInterval => self::streamDuration((string) $value),
             'read_time' => static fn (EntryContract $entry, mixed $value): CarbonInterval => self::streamDuration((string) $entry->value('duration')),
             'transcript_text' => static fn (EntryContract $entry, mixed $value): ?string => self::streamTranscript($entry),
@@ -116,7 +125,6 @@ class AppServiceProvider extends ServiceProvider
     private static function streamTranscript(EntryContract $entry): ?string
     {
         $path = (string) $entry->value('transcript');
-
         if (blank($path)) {
             return null;
         }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -125,6 +125,7 @@ class AppServiceProvider extends ServiceProvider
     private static function streamTranscript(EntryContract $entry): ?string
     {
         $path = (string) $entry->value('transcript');
+
         if (blank($path)) {
             return null;
         }

--- a/app/Services/OpenGraphImage.php
+++ b/app/Services/OpenGraphImage.php
@@ -7,9 +7,9 @@ use Statamic\Contracts\Imaging\UrlBuilder;
 
 class OpenGraphImage
 {
-    public const WIDTH = 2048;
+    public const int WIDTH = 2048;
 
-    public const HEIGHT = 1170;
+    public const int HEIGHT = 1170;
 
     public static function url(mixed $page = null): string
     {

--- a/app/Services/OpenGraphImage.php
+++ b/app/Services/OpenGraphImage.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Services;
+
+use Statamic\Contracts\Entries\Entry as EntryContract;
+use Statamic\Contracts\Imaging\UrlBuilder;
+
+class OpenGraphImage
+{
+    public const WIDTH = 2048;
+
+    public const HEIGHT = 1170;
+
+    public static function url(mixed $page = null): string
+    {
+        return url(app(UrlBuilder::class)->build('images::'.self::path($page), []));
+    }
+
+    private static function path(mixed $page): string
+    {
+        if (! $page instanceof EntryContract) {
+            return 'og/static/home.png';
+        }
+
+        $collection = $page->collection()->handle();
+
+        if (in_array($collection, ['posts', 'streams'], true)) {
+            return sprintf(
+                'og/%s/%s.%s.png',
+                $collection,
+                $page->date()->format('Y-m-d'),
+                $page->slug(),
+            );
+        }
+
+        if ($collection === 'pages') {
+            $slug = request()->path() === '/'
+                ? 'home'
+                : $page->slug();
+
+            return "og/static/{$slug}.png";
+        }
+
+        return 'og/static/home.png';
+    }
+}

--- a/app/Services/OpenGraphImage.php
+++ b/app/Services/OpenGraphImage.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use Illuminate\Support\Str;
 use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\Contracts\Imaging\UrlBuilder;
 
@@ -11,36 +12,31 @@ class OpenGraphImage
 
     public const int HEIGHT = 1170;
 
-    public static function url(mixed $page = null): string
+    public static function path(EntryContract $entry): string
     {
-        return url(app(UrlBuilder::class)->build('images::'.self::path($page), []));
-    }
-
-    private static function path(mixed $page): string
-    {
-        if (! $page instanceof EntryContract) {
-            return 'og/static/home.png';
-        }
-
-        $collection = $page->collection()->handle();
-
-        if (in_array($collection, ['posts', 'streams'], true)) {
-            return sprintf(
-                'og/%s/%s.%s.png',
-                $collection,
-                $page->date()->format('Y-m-d'),
-                $page->slug(),
-            );
-        }
+        $collection = $entry->collection()->handle();
 
         if ($collection === 'pages') {
-            $slug = request()->path() === '/'
+            $slug = $entry->uri() === '/'
                 ? 'home'
-                : $page->slug();
+                : $entry->slug();
 
-            return "og/static/{$slug}.png";
+            return "images/og/static/{$slug}.png";
         }
 
-        return 'og/static/home.png';
+        return sprintf(
+            'images/og/%s/%s.%s.png',
+            $collection,
+            $entry->date()->format('Y-m-d'),
+            $entry->slug(),
+        );
+    }
+
+    public static function url(string $path): string
+    {
+        return url(app(UrlBuilder::class)->build(
+            'images::'.Str::after($path, 'images/'),
+            [],
+        ));
     }
 }

--- a/app/View/Components/Og/Article.php
+++ b/app/View/Components/Og/Article.php
@@ -24,7 +24,7 @@ class Article extends Component
     {
         $title = $this->post->value('title').' | '.$this->name;
         $description = (string) $this->post->value('description');
-        $image = OpenGraphImage::url($this->post);
+        $image = OpenGraphImage::url((string) $this->post->og_image);
 
         return implode(PHP_EOL, [
             OpenGraph::article($title)

--- a/app/View/Components/Og/Article.php
+++ b/app/View/Components/Og/Article.php
@@ -2,6 +2,7 @@
 
 namespace App\View\Components\Og;
 
+use App\Services\OpenGraphImage;
 use Astrotomic\OpenGraph\OpenGraph;
 use Astrotomic\OpenGraph\Twitter;
 use Illuminate\View\Component;
@@ -23,15 +24,18 @@ class Article extends Component
     {
         $title = $this->post->value('title').' | '.$this->name;
         $description = (string) $this->post->value('description');
+        $image = OpenGraphImage::url($this->post);
 
         return implode(PHP_EOL, [
             OpenGraph::article($title)
                 ->url((string) $this->post->absoluteUrl())
+                ->image($image)
                 ->when($description)->description($description)
                 ->publishedAt($this->post->date())
                 ->modifiedAt($this->post->last_modified_at->toDateTime())
                 ->locale(str_replace('-', '_', app()->getLocale())),
             Twitter::summaryLargeImage($title)
+                ->image($image, (string) $this->post->value('title'))
                 ->when($description)->description($description),
         ]);
     }

--- a/resources/views/components/og/profile.blade.php
+++ b/resources/views/components/og/profile.blade.php
@@ -4,7 +4,8 @@
 ])
 
 @php
-    $image = \App\Services\OpenGraphImage::url($page);
+    $image = $page?->og_image ?? null;
+    $image = $image ? \App\Services\OpenGraphImage::url((string) $image) : null;
     $imageAlt = $page?->title ?? $identity->name;
 @endphp
 
@@ -24,26 +25,28 @@
     property="og:locale"
     content="{{ str_replace('-', '_', app()->getLocale()) }}"
 />
-<meta
-    property="og:image"
-    content="{{ $image }}"
-/>
-<meta
-    property="og:image:type"
-    content="image/png"
-/>
-<meta
-    property="og:image:width"
-    content="{{ \App\Services\OpenGraphImage::WIDTH }}"
-/>
-<meta
-    property="og:image:height"
-    content="{{ \App\Services\OpenGraphImage::HEIGHT }}"
-/>
-<meta
-    property="og:image:alt"
-    content="{{ $imageAlt }}"
-/>
+@if ($image)
+    <meta
+        property="og:image"
+        content="{{ $image }}"
+    />
+    <meta
+        property="og:image:type"
+        content="image/png"
+    />
+    <meta
+        property="og:image:width"
+        content="{{ \App\Services\OpenGraphImage::WIDTH }}"
+    />
+    <meta
+        property="og:image:height"
+        content="{{ \App\Services\OpenGraphImage::HEIGHT }}"
+    />
+    <meta
+        property="og:image:alt"
+        content="{{ $imageAlt }}"
+    />
+@endif
 @if ($page?->description)
     <meta
         property="og:description"
@@ -52,20 +55,22 @@
 @endif
 <meta
     name="twitter:card"
-    content="summary_large_image"
+    content="{{ $image ? 'summary_large_image' : 'summary' }}"
 />
 <meta
     name="twitter:title"
     content="{{ $page?->title ? $page->title.' | '.$identity->name : $identity->name }}"
 />
-<meta
-    name="twitter:image"
-    content="{{ $image }}"
-/>
-<meta
-    name="twitter:image:alt"
-    content="{{ $imageAlt }}"
-/>
+@if ($image)
+    <meta
+        name="twitter:image"
+        content="{{ $image }}"
+    />
+    <meta
+        name="twitter:image:alt"
+        content="{{ $imageAlt }}"
+    />
+@endif
 @if ($page?->description)
     <meta
         name="twitter:description"

--- a/resources/views/components/og/profile.blade.php
+++ b/resources/views/components/og/profile.blade.php
@@ -3,6 +3,11 @@
     'page' => null,
 ])
 
+@php
+    $image = \App\Services\OpenGraphImage::url($page);
+    $imageAlt = $page?->title ?? $identity->name;
+@endphp
+
 <meta
     property="og:type"
     content="profile"
@@ -19,6 +24,26 @@
     property="og:locale"
     content="{{ str_replace('-', '_', app()->getLocale()) }}"
 />
+<meta
+    property="og:image"
+    content="{{ $image }}"
+/>
+<meta
+    property="og:image:type"
+    content="image/png"
+/>
+<meta
+    property="og:image:width"
+    content="{{ \App\Services\OpenGraphImage::WIDTH }}"
+/>
+<meta
+    property="og:image:height"
+    content="{{ \App\Services\OpenGraphImage::HEIGHT }}"
+/>
+<meta
+    property="og:image:alt"
+    content="{{ $imageAlt }}"
+/>
 @if ($page?->description)
     <meta
         property="og:description"
@@ -32,6 +57,14 @@
 <meta
     name="twitter:title"
     content="{{ $page?->title ? $page->title.' | '.$identity->name : $identity->name }}"
+/>
+<meta
+    name="twitter:image"
+    content="{{ $image }}"
+/>
+<meta
+    name="twitter:image:alt"
+    content="{{ $imageAlt }}"
 />
 @if ($page?->description)
     <meta

--- a/resources/views/components/og/website.blade.php
+++ b/resources/views/components/og/website.blade.php
@@ -3,6 +3,11 @@
     'page' => null,
 ])
 
+@php
+    $image = \App\Services\OpenGraphImage::url($page);
+    $imageAlt = $page?->title ?? $identity->name;
+@endphp
+
 <meta
     property="og:type"
     content="website"
@@ -19,6 +24,26 @@
     property="og:locale"
     content="{{ str_replace('-', '_', app()->getLocale()) }}"
 />
+<meta
+    property="og:image"
+    content="{{ $image }}"
+/>
+<meta
+    property="og:image:type"
+    content="image/png"
+/>
+<meta
+    property="og:image:width"
+    content="{{ \App\Services\OpenGraphImage::WIDTH }}"
+/>
+<meta
+    property="og:image:height"
+    content="{{ \App\Services\OpenGraphImage::HEIGHT }}"
+/>
+<meta
+    property="og:image:alt"
+    content="{{ $imageAlt }}"
+/>
 @if ($page?->description)
     <meta
         property="og:description"
@@ -32,6 +57,14 @@
 <meta
     name="twitter:title"
     content="{{ $page?->title ? $page->title.' | '.$identity->name : $identity->name }}"
+/>
+<meta
+    name="twitter:image"
+    content="{{ $image }}"
+/>
+<meta
+    name="twitter:image:alt"
+    content="{{ $imageAlt }}"
 />
 @if ($page?->description)
     <meta

--- a/resources/views/components/og/website.blade.php
+++ b/resources/views/components/og/website.blade.php
@@ -4,7 +4,8 @@
 ])
 
 @php
-    $image = \App\Services\OpenGraphImage::url($page);
+    $image = $page?->og_image ?? null;
+    $image = $image ? \App\Services\OpenGraphImage::url((string) $image) : null;
     $imageAlt = $page?->title ?? $identity->name;
 @endphp
 
@@ -24,26 +25,28 @@
     property="og:locale"
     content="{{ str_replace('-', '_', app()->getLocale()) }}"
 />
-<meta
-    property="og:image"
-    content="{{ $image }}"
-/>
-<meta
-    property="og:image:type"
-    content="image/png"
-/>
-<meta
-    property="og:image:width"
-    content="{{ \App\Services\OpenGraphImage::WIDTH }}"
-/>
-<meta
-    property="og:image:height"
-    content="{{ \App\Services\OpenGraphImage::HEIGHT }}"
-/>
-<meta
-    property="og:image:alt"
-    content="{{ $imageAlt }}"
-/>
+@if ($image)
+    <meta
+        property="og:image"
+        content="{{ $image }}"
+    />
+    <meta
+        property="og:image:type"
+        content="image/png"
+    />
+    <meta
+        property="og:image:width"
+        content="{{ \App\Services\OpenGraphImage::WIDTH }}"
+    />
+    <meta
+        property="og:image:height"
+        content="{{ \App\Services\OpenGraphImage::HEIGHT }}"
+    />
+    <meta
+        property="og:image:alt"
+        content="{{ $imageAlt }}"
+    />
+@endif
 @if ($page?->description)
     <meta
         property="og:description"
@@ -52,20 +55,22 @@
 @endif
 <meta
     name="twitter:card"
-    content="summary_large_image"
+    content="{{ $image ? 'summary_large_image' : 'summary' }}"
 />
 <meta
     name="twitter:title"
     content="{{ $page?->title ? $page->title.' | '.$identity->name : $identity->name }}"
 />
-<meta
-    name="twitter:image"
-    content="{{ $image }}"
-/>
-<meta
-    name="twitter:image:alt"
-    content="{{ $imageAlt }}"
-/>
+@if ($image)
+    <meta
+        name="twitter:image"
+        content="{{ $image }}"
+    />
+    <meta
+        name="twitter:image:alt"
+        content="{{ $imageAlt }}"
+    />
+@endif
 @if ($page?->description)
     <meta
         name="twitter:description"

--- a/resources/views/pages/contact.blade.php
+++ b/resources/views/pages/contact.blade.php
@@ -1,5 +1,9 @@
 @extends ('web')
 
+@push ('head')
+    <x-og.website />
+@endpush
+
 @section ('content')
     <x-article class="prose max-w-none md:prose-lg lg:prose-xl"> {!! $content !!} </x-article>
 @endsection

--- a/resources/views/pages/imprint.blade.php
+++ b/resources/views/pages/imprint.blade.php
@@ -1,5 +1,9 @@
 @extends ('web')
 
+@push ('head')
+    <x-og.website />
+@endpush
+
 @section ('content')
     <x-article class="prose max-w-none md:prose-lg lg:prose-xl"> {!! $content !!} </x-article>
 @endsection

--- a/resources/views/pages/privacy.blade.php
+++ b/resources/views/pages/privacy.blade.php
@@ -1,5 +1,9 @@
 @extends ('web')
 
+@push ('head')
+    <x-og.website />
+@endpush
+
 @section ('content')
     <x-article class="prose max-w-none md:prose-lg lg:prose-xl"> {!! $content !!} </x-article>
 @endsection


### PR DESCRIPTION
The generated OG images were sitting in the image container but never referenced by the page metadata.

This PR now keeps the image path on the content itself instead of rebuilding it in multiple places:

- adds a computed `og_image` value to every routed collection (`pages`, `posts`, `streams`)
- uses that value for both OG generation and metadata embedding
- keeps OG image dimensions centralized in `OpenGraphImage` and uses them for both generation and metadata
- adds `og:image` plus image type/dimensions/alt metadata to website/profile cards when an `og_image` is available
- adds `twitter:image` metadata as well
- attaches the computed post image to the existing article OpenGraph/Twitter output
- adds the existing OG component to Contact, Imprint and Privacy so their generated static images are actually used

The homepage keeps its dedicated `home.png` path through the same computed value, so generation and embedding cannot drift apart anymore.