### PR TITLE
Draft Analytics without visitors

### DIFF
--- a/content/collections/posts/2026-09-11.analytics-without-visitors.md
+++ b/content/collections/posts/2026-09-11.analytics-without-visitors.md
@@ -4,22 +4,70 @@ blueprint: post
 published: false
 title: 'Analytics without visitors'
 category: engineering
-description: 'How moving my analytics server-side ended with a tiny schema that deliberately forgets which metrics belonged to the same request.'
+description: 'Why my self-hosted analytics still knew too much and too little for this site, and how that became Untracked: analytics without a visitor model.'
 date: 1789147080
 author: gummibeer
 ---
 
-While going through some privacy stuff on this site I looked at the Umami tracker I already had and asked a pretty boring question:
+The absolute beginning of this wasn't server-side analytics.
+It was privacy law.
 
-Can I just track this server-side?
+Every time I touch analytics, the same alphabet soup pops up again: the EU [General Data Protection Regulation (GDPR)](https://commission.europa.eu/law/law-topic/data-protection/legal-framework-eu-data-protection_en), the [UK GDPR](https://ico.org.uk/about-the-ico/what-we-do/legislation-we-cover/general-data-protection-regulation/), California's [Consumer Privacy Act (CCPA)](https://www.oag.ca.gov/privacy/ccpa) and [Privacy Rights Act (CPRA)](https://cppa.ca.gov/faq), Canada's [Personal Information Protection and Electronic Documents Act (PIPEDA)](https://laws-lois.justice.gc.ca/eng/acts/P-8.6/) and Brazil's [Lei Geral de Proteção de Dados (LGPD)](https://www.gov.br/governodigital/pt-br/lgpd-pagina-do-cidadao/o-que-e-a-lgpd).
 
-This site doesn't only serve HTML to normal browsers anymore.
-It also serves Markdown responses, feeds, bots, AI agents and whatever else directly talks to the server.
-A JavaScript tracker will never see all of that.
+I'm not running a shop here.
+There are no ads and no commercial part of this site where detailed visitor analytics would somehow be business-critical.
+I was already self-hosting [Umami](https://umami.is), specifically because I didn't want Google Analytics or another third party following people around.
 
-So the first idea was simply to move the same analytics server-side.
+And still I increasingly felt like I was operating in a gray area I didn't need to be in.
 
-Then I started thinking about what I actually want from analytics and ended up building a new analytics app instead. 😅
+The weird part was that Umami knew **too much and too little at the same time**.
+
+Weird combo, I know.
+Let me explain.
+
+Umami doesn't store the raw visitor IP as `1.2.3.4` in the analytics database.
+That's good.
+
+But a pageview is still stored as activity related to a session.
+That session/activity model can connect the page and query, referrer, country and location data, browser, version-specific operating-system information, device type, screen resolution, language and an exact timestamp.
+The exact storage is split between events and sessions, but from my perspective that doesn't really change the important part: the values still belong together and can be queried as one visitor/session history.
+
+And those sessions aren't necessarily a single short browser visit either.
+Umami creates a session identifier from request/client information and a rotating salt, so the same session can span multiple days within that salt window.
+
+On a giant website that's one thing.
+On my personal site with comparatively little traffic, an exact timestamp plus page/query, country, browser/OS and a session connecting several visits can be enough context for me to recognize who a visit probably was.
+
+No IP column doesn't magically make all the other information anonymous.
+
+So that was the **too much** part.
+
+At the same time Umami told me basically nothing about an audience I had just explicitly started building for.
+
+I added content negotiation to this site so a request doesn't necessarily get HTML anymore.
+Bots and AI agents can ask for Markdown, feeds already exist, and normal crawlers directly talk to the server without ever executing my JavaScript tracker.
+
+So if Googlebot crawls a page, I want to know that.
+If ChatGPT or another AI agent is actually requesting or recommending content from my site, I'm interested in that too.
+Not who the human behind it is - just that this kind of traffic exists and which content gets requested.
+
+My analytics was blind to exactly that traffic.
+
+That was the **too little** part.
+
+First I checked whether I could simply keep Umami and move the tracking server-side.
+Umami does have a server-side events API, but it still feeds Umami's event/session model.
+There isn't a mode matching what I wanted where I can send already reduced values and say: increment this page counter, this country counter and this browser counter without constructing another correlated visitor/session record around them.
+And bot/agent traffic isn't really a first-class analytics audience there either.
+
+At that point the next thought was pretty obvious:
+
+I'm already self-hosting my analytics.
+Operationally it doesn't make much difference whether the thing I'm self-hosting is Umami or something else.
+
+So I started building [Untracked](https://github.com/Astrotomic/untracked).
+
+Then I started thinking about what I actually want from analytics and the storage model got smaller and smaller. 😅
 
 ## I don't need visitors
 

--- a/content/collections/posts/2026-09-11.analytics-without-visitors.md
+++ b/content/collections/posts/2026-09-11.analytics-without-visitors.md
@@ -1,0 +1,425 @@
+---
+id: 6cde005d-63d2-4163-a655-a64eecbc7adc
+blueprint: post
+published: false
+title: 'Analytics without visitors'
+category: engineering
+description: 'How moving my analytics server-side ended with a tiny schema that deliberately forgets which metrics belonged to the same request.'
+date: 1789147080
+author: gummibeer
+---
+
+While going through some privacy stuff on this site I looked at the Umami tracker I already had and asked a pretty boring question:
+
+Can I just track this server-side?
+
+This site doesn't only serve HTML to normal browsers anymore.
+It also serves Markdown responses, feeds, bots, AI agents and whatever else directly talks to the server.
+A JavaScript tracker will never see all of that.
+
+So the first idea was simply to move the same analytics server-side.
+
+Then I started thinking about what I actually want from analytics and ended up building a new analytics app instead. 😅
+
+## I don't need visitors
+
+Umami is already on the privacy-friendly side of analytics and I still like it.
+But like basically every normal analytics product it has concepts around visits and visitors because that's useful for normal analytics.
+
+I don't need that.
+
+I don't need a visitor ID.
+I don't need sessions.
+I don't need a fingerprint, hashed IP or another identifier with a nicer name.
+I don't even need individual request rows.
+
+What I actually want is much more boring:
+
+```text
+/blog/example  123
+DE              87
+Firefox         51
+Linux           44
+desktop         92
+google.com      31
+```
+
+Counts.
+
+That was the point where this stopped being "send analytics from the backend" and became a different storage problem.
+
+## The first schema was still wrong
+
+The obvious aggregate table would be something like:
+
+```text
+date
+path
+country
+browser
+os
+device
+format
+count
+```
+
+No exact timestamp, no IP, no User-Agent, no visitor ID.
+Looks pretty decent already.
+
+But it still stores one important thing I don't need: the relationship between all those values.
+
+With that table I can still ask:
+
+> How many Firefox requests from Germany opened `/blog/example` on Linux?
+
+Why should I be able to answer that?
+
+I never wanted that information in the first place.
+
+So instead of only removing the visitor identifier I also removed the relation between the dimensions.
+
+The analytics table in [Untracked](https://github.com/Astrotomic/untracked) is this:
+
+```php
+Schema::create('daily_metrics', function (Blueprint $table): void {
+    $table->foreignUuid('website_uuid')->index()
+        ->constrained('websites', 'uuid')
+        ->cascadeOnDelete();
+
+    $table->date('date')->index();
+    $table->string('metric', 32)->index();
+    $table->string('value', 500)->index();
+    $table->unsignedBigInteger('count')->default(0);
+
+    $table->primary([
+        'website_uuid',
+        'date',
+        'metric',
+        'value',
+    ]);
+});
+```
+
+That's it.
+
+A single request can increment these counters:
+
+```text
+2026-09-11 | path         | /blog/example        | +1
+2026-09-11 | country      | DE                   | +1
+2026-09-11 | browser      | Firefox              | +1
+2026-09-11 | os           | Linux                | +1
+2026-09-11 | device       | desktop              | +1
+2026-09-11 | format       | markdown             | +1
+2026-09-11 | referrer     | news.ycombinator.com | +1
+2026-09-11 | utm_source   | newsletter           | +1
+```
+
+But afterwards nothing says that those rows came from the same request.
+
+I can know that `/blog/example` had 123 requests and Germany had 87.
+I can't know how many of those 87 German requests opened `/blog/example`.
+
+I can know that 31 requests came from Google and that `/blog/example` had 123 requests.
+I can't know how many Google referrers pointed to that page.
+
+I can know how often a campaign value appeared.
+I can't rebuild a request from source + campaign + browser + page afterwards.
+
+That loss of information is intentional.
+
+And it's probably my favorite part of the whole thing.
+
+## No event table hiding behind it
+
+There also isn't an event table that stores the full request first and aggregates it later.
+
+No nightly cleanup job.
+No queue payload with all raw dimensions waiting around.
+No `created_at` or `updated_at` on the analytics rows.
+
+The request is normalized in memory and the counters are incremented immediately.
+
+Exact timestamps would actually be especially stupid here.
+If all rows produced by one request had the same timestamp I would have created a correlation key right after removing all the other ones. 🤦‍♂️
+
+One day is enough for what I want to know.
+
+## Keep the raw client stupid
+
+After the storage model was clear I also wanted the raw collector to be as dumb as possible.
+
+It needs four values:
+
+```text
+full URL
+IP
+User-Agent
+referrer
+```
+
+For a browser integration only two of those need to be sent explicitly because the IP and User-Agent already arrive with the HTTP request.
+
+So the bundled script is basically this:
+
+```js
+(() => {
+    const script = document.currentScript;
+    const website = script?.dataset.websiteId;
+
+    if (! website) {
+        return;
+    }
+
+    const endpoint = new URL(
+        `/api/websites/${encodeURIComponent(website)}/collect/raw`,
+        script.src,
+    );
+
+    const body = new URLSearchParams({
+        url: window.location.href,
+        referrer: document.referrer,
+    });
+
+    fetch(endpoint, {
+        method: 'POST',
+        body,
+        keepalive: true,
+        credentials: 'omit',
+    }).catch(() => {});
+})();
+```
+
+No UTM parsing in JavaScript.
+No browser detection.
+No path extraction.
+No referrer cleanup.
+
+The server has PHP. It can do work.
+
+The model boundary ends up being pretty literal:
+
+```php
+$website->recordRaw(
+    url: $validated['url'],
+    ip: (string) $request->ip(),
+    userAgent: (string) $request->userAgent(),
+    referrer: $validated['referrer'] ?? null,
+);
+```
+
+From those values Untracked derives everything it needs before storing anything:
+
+```text
+full URL
+  -> path
+  -> utm_source
+  -> utm_medium
+  -> utm_campaign
+  -> utm_term
+  -> utm_content
+
+IP
+  -> country
+
+User-Agent
+  -> browser
+  -> operating system
+  -> device
+
+referrer
+  -> domain
+```
+
+The full URL and referrer do reach the Untracked server for raw collection.
+That's unavoidable if the server should do the parsing.
+But they only exist during the request and aren't persisted as analytics data.
+
+## User-Agent parsing without accidentally combining dimensions again
+
+I'm using [`ua-parser/uap-php`](https://packagist.org/packages/ua-parser/uap-php) for User-Agent parsing.
+
+UAP already separates browser and operating-system families from their version fields, which is nice because I don't need `Firefox 142.0.1` or `Windows 10`.
+
+But the family names can still contain information from another dimension:
+
+```text
+Firefox iOS
+Chrome Mobile iOS
+Edge Mobile
+Mobile Safari
+```
+
+Storing `Firefox iOS` as the browser would already combine browser and operating system again.
+Exactly what I just tried to avoid.
+
+So the parsed families go through another semantic normalization step:
+
+```text
+Firefox iOS                -> Firefox
+Chrome Mobile iOS          -> Chrome
+Chrome Mobile WebView      -> Chrome WebView
+Edge Mobile                -> Edge
+Mobile Safari              -> Safari
+```
+
+Same for operating systems:
+
+```text
+Windows XP          -> Windows
+Windows Vista       -> Windows
+Windows 10          -> Windows
+Windows Server 2003 -> Windows
+
+Ubuntu              -> Linux
+Debian              -> Linux
+Fedora              -> Linux
+```
+
+Browser and operating system are intentionally not enums.
+UAP is data-driven and new family names can appear, so turning that open set into a giant enum would just mean maintaining a worse copy of UAP.
+
+Unknown families survive as their family name unless there is something I explicitly want to remove from them.
+
+Device is different and stays deliberately boring:
+
+```text
+desktop
+mobile
+tablet
+bot
+other
+```
+
+I also don't collect screen dimensions just to distinguish a laptop from a desktop.
+Both are desktop.
+Good enough.
+
+## Unknown means null
+
+Country lookup follows the same idea.
+
+The default driver uses a local MaxMind database, so the IP can be reduced to a country without sending the IP to another service.
+There is also an `ip-api.com` driver for setups where that tradeoff is fine.
+
+The IP itself is never stored.
+
+At one point the fallback country was `XX`.
+
+And then I looked at it and wondered why I was using a magic string for something PHP already has a type for. 😅
+
+If I don't know the country, it's `null`.
+
+Because the metric storage is sparse anyway, `null` simply means there is no country row for that request.
+No fake "unknown country" value that looks like real data.
+
+The same principle applies to optional attribution dimensions.
+No referrer means no referrer row.
+No `utm_campaign` means no campaign row.
+
+I don't need `(direct)`, `(unknown)` or other magic buckets stored just so every request produces the same number of rows.
+
+## Referrers and UTM parameters
+
+Referrers are reduced to the domain only.
+
+```text
+https://news.ycombinator.com/item?id=123
+```
+
+becomes:
+
+```text
+news.ycombinator.com
+```
+
+Same-site referrers are dropped completely.
+
+Again, the useful part is what I can't ask afterwards.
+
+I can see that Hacker News sent 200 requests.
+I can see that a post had 500 requests.
+I cannot ask how many of those Hacker News requests went to that post.
+
+The standard UTM parameters are stored as separate metrics as well:
+
+```text
+utm_source
+utm_medium
+utm_campaign
+utm_term
+utm_content
+```
+
+That means I can count the values individually, but I can't later reconstruct a source + medium + campaign + page combination.
+
+For a marketing analytics product that would be a pretty terrible limitation.
+
+For this project it's the feature.
+
+## Processed collection
+
+The raw endpoint is useful when I want Untracked to derive everything itself.
+But for server-side integrations there is no reason to send raw information if the source application already knows the coarse values.
+
+So there is a second endpoint that accepts processed dimensions directly:
+
+```json
+{
+  "path": "/blog/example",
+  "country": "DE",
+  "browser": "Firefox",
+  "os": "Linux",
+  "device": "desktop",
+  "format": "markdown",
+  "referrer": "news.ycombinator.com",
+  "utm_source": "newsletter"
+}
+```
+
+That's the endpoint I care about most for this site.
+
+It means HTML, Markdown, feeds, bots and AI agents can all be counted from the same server-side request flow without pretending the whole web executes JavaScript.
+
+And if the source already knows something - for example because a proxy provides the visitor country - it can send the reduced value directly instead of shipping the IP somewhere else just to calculate it again.
+
+## Bots
+
+Bots are configurable per website.
+
+If bot tracking is disabled, the request is discarded before any metric is incremented.
+
+If it is enabled, I still don't need the exact crawler identity mixed into every dimension.
+It gets reduced to coarse bot values instead.
+
+Again: only keep information I actually intend to use.
+
+## Does this magically solve privacy law?
+
+No.
+
+The raw collector still receives a normal HTTP request.
+Your web server, reverse proxy, CDN or hosting platform can have access logs completely outside of Untracked.
+An external IP lookup driver obviously sends the IP to that service.
+And URLs themselves can contain personal data if an application is stupid enough to put personal data into routes or UTM parameters.
+
+This architecture is about data minimization and making correlation impossible in the analytics database by design.
+It isn't a GDPR sticker I can slap onto any deployment.
+
+For me the useful rule is much simpler:
+
+**There is no visitor model.**
+
+Not an anonymous visitor.
+Not a pseudonymous visitor.
+Not a hashed visitor.
+No visitor.
+
+If a future feature needs sessions, fingerprints, unique visitors or some identifier that lets me connect requests again, it doesn't belong in Untracked.
+
+The first implementation is now on GitHub at [Astrotomic/untracked](https://github.com/Astrotomic/untracked).
+There is plenty left to do around the actual dashboard and deployment, but the part I cared about is already fixed by the schema.
+
+The database can't answer questions I never wanted to ask.
+
+That's the feature.

--- a/content/collections/posts/2026-09-11.analytics-without-visitors.md
+++ b/content/collections/posts/2026-09-11.analytics-without-visitors.md
@@ -431,16 +431,92 @@ It means HTML, Markdown, feeds, bots and AI agents can all be counted from the s
 
 And if the source already knows something - for example because a proxy provides the visitor country - it can send the reduced value directly instead of shipping the IP somewhere else just to calculate it again.
 
-## Bots
+## Bots need different dimensions
 
-Bots are configurable per website.
+The first bot implementation was technically working and still pretty useless.
 
-If bot tracking is disabled, the request is discarded before any metric is incremented.
+The official OpenAI and Anthropic User-Agents in my tests basically ended up as:
 
-If it is enabled, I still don't need the exact crawler identity mixed into every dimension.
-It gets reduced to coarse bot values instead.
+```text
+browser  Bot
+os       Other
+device   bot
+country  US
+```
 
-Again: only keep information I actually intend to use.
+OpenAI, Anthropic, Google - everything became `Bot`.
+
+That's crap.
+
+For humans there is a privacy reason to aggressively remove details.
+For a crawler operated by OpenAI there isn't.
+I don't need to protect GPTBot from me figuring out that it belongs to OpenAI. 😅
+
+At the same time some of the normal human dimensions are actively misleading for bots.
+
+A crawler running from US infrastructure doesn't mean the US is part of my human audience.
+If that goes into the same country counter as normal requests, bot traffic slowly poisons the country distribution and I can't subtract it again because I deliberately removed correlation between dimensions.
+
+Same for attribution.
+If a crawler requests a URL containing `utm_source=newsletter`, that only means it found that URL somewhere.
+It was not part of the newsletter audience.
+A referrer from a bot has the same problem.
+
+So bot dimensions now get normalized differently.
+
+For bots I keep:
+
+```text
+path
+client/company
+device = bot
+format
+```
+
+And I drop:
+
+```text
+country
+os
+referrer
+utm_source
+utm_medium
+utm_campaign
+utm_term
+utm_content
+```
+
+The country lookup isn't only discarded afterwards either.
+For raw bot requests it isn't performed at all.
+No reason to resolve an IP I already know I won't use.
+
+The User-Agent parser also keeps something useful now.
+Known bot signatures are mapped to the company behind them:
+
+```text
+GPTBot / ChatGPT-User / OAI-SearchBot -> OpenAI
+ClaudeBot / Claude-User               -> Anthropic
+Googlebot / Google-Agent              -> Google
+```
+
+`device` is still `bot`.
+The OS becomes `null`, because `Other` would only be a magic string pretending there was information there.
+And if I know it's a bot but don't know who operates it, the client/company is `null` as well instead of another useless `Bot` bucket.
+
+So an OpenAI agent requesting this post as Markdown can become:
+
+```text
+path     /blog/2026/analytics-without-visitors
+browser  OpenAI
+device   bot
+format   markdown
+```
+
+No fake US audience.
+No fake operating system.
+No campaign attribution because a crawler happened to discover a tagged URL.
+
+That leaves the metrics bots can actually answer without poisoning the metrics meant for humans.
 
 ## Does this magically solve privacy law?
 


### PR DESCRIPTION
## What

Add an unpublished engineering post draft about the story and architecture behind Untracked.

The post focuses on the actual reasoning that led from "track gummibeer.dev server-side" to a storage model that deliberately destroys correlations between metrics:

- no visitor/session model
- independent daily counters instead of request/event rows
- no exact timestamps
- four-value raw collector input
- server-side URL/UTM/referrer/UA/IP reduction
- semantic browser/OS normalization
- nullable country instead of an `XX` sentinel
- processed collection for already-coarsened server-side integrations

The wording follows the project writing-style guide and keeps the post unpublished for review.